### PR TITLE
Add role selection step to onboarding flow

### DIFF
--- a/app/src/pages/onboarding.tsx
+++ b/app/src/pages/onboarding.tsx
@@ -2,10 +2,11 @@ import { useMemo, useState } from 'react';
 import Head from 'next/head';
 
 import LanguageStep from '@/components/onboarding/LanguageStep';
+import RoleSelectionStep from '@/components/onboarding/RoleSelectionStep';
 import SkillProfileStep from '@/components/onboarding/SkillProfileStep';
 import TimezoneStep from '@/components/onboarding/TimezoneStep';
 
-const STEP_COMPONENTS: Array<() => JSX.Element> = [LanguageStep, TimezoneStep, SkillProfileStep];
+const STEP_COMPONENTS: Array<() => JSX.Element> = [LanguageStep, TimezoneStep, SkillProfileStep, RoleSelectionStep];
 
 export default function OnboardingPage() {
   const [currentStepIndex, setCurrentStepIndex] = useState(0);


### PR DESCRIPTION
## Summary
- import the role selection step into the onboarding wizard
- append the role selection screen to the onboarding step sequence

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ce2f63caa08327b0ba2998cc23ccca