### PR TITLE
refactor: reuse onboarding progress component

### DIFF
--- a/app/src/components/onboarding/RoleSelectionStep.tsx
+++ b/app/src/components/onboarding/RoleSelectionStep.tsx
@@ -4,6 +4,8 @@ import { useQuery } from '@tanstack/react-query';
 import { fetchMatchOverview } from '@/lib/api';
 import { useUserProfile } from '@/store/useUserProfile';
 
+import OnboardingProgress from './OnboardingProgress';
+
 const SESSION_REWARD_USD = 65;
 
 function formatUsd(amount: number) {
@@ -84,15 +86,7 @@ export default function RoleSelectionStep() {
             выгодный сценарий прямо сейчас.
           </p>
         </div>
-        <div className="flex items-center gap-2">
-          <span className="text-xs uppercase tracking-wide text-slate-500">Progress</span>
-          <div className="flex items-center gap-1">
-            <span className="h-2 w-8 rounded-full bg-secondary" />
-            <span className="h-2 w-8 rounded-full bg-secondary" />
-            <span className="h-2 w-8 rounded-full bg-slate-700" />
-            <span className="h-2 w-8 rounded-full bg-secondary" />
-          </div>
-        </div>
+        <OnboardingProgress currentStep={4} totalSteps={4} />
       </header>
 
       <div className="mt-8 grid gap-5 md:grid-cols-2">

--- a/app/src/components/onboarding/SkillProfileStep.tsx
+++ b/app/src/components/onboarding/SkillProfileStep.tsx
@@ -9,6 +9,8 @@ import {
 import { useSaveOnboardingDraft } from '@/hooks/useOnboardingDraft';
 import { useUserProfile } from '@/store/useUserProfile';
 
+import OnboardingProgress from './OnboardingProgress';
+
 const CATEGORY_TITLES: Record<ProfessionCategory, string> = {
   'core-engineering': 'Основные роли разработки',
   'specialized-engineering': 'Специализированные инженерные роли',
@@ -137,14 +139,7 @@ export default function SkillProfileStep() {
             technologies you are most confident in today.
           </p>
         </div>
-        <div className="flex items-center gap-2">
-          <span className="text-xs uppercase tracking-wide text-slate-500">Progress</span>
-          <div className="flex items-center gap-1">
-            <span className="h-2 w-8 rounded-full bg-secondary" />
-            <span className="h-2 w-8 rounded-full bg-secondary" />
-            <span className="h-2 w-8 rounded-full bg-secondary" />
-          </div>
-        </div>
+        <OnboardingProgress currentStep={3} totalSteps={4} />
       </header>
 
       <div className="mt-8 space-y-10">

--- a/app/src/components/onboarding/TimezoneStep.tsx
+++ b/app/src/components/onboarding/TimezoneStep.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
 
 import { useUserProfile } from '@/store/useUserProfile';
+
+import OnboardingProgress from './OnboardingProgress';
 import type { SupportedLanguage } from '../../../../shared/src/types/user.js';
 
 const LANGUAGE_TO_INTL_LOCALE: Record<SupportedLanguage, string> = {
@@ -159,14 +161,7 @@ export default function TimezoneStep() {
             availability and notifications accurate.
           </p>
         </div>
-        <div className="flex items-center gap-2">
-          <span className="text-xs uppercase tracking-wide text-slate-500">Progress</span>
-          <div className="flex items-center gap-1">
-            <span className="h-2 w-8 rounded-full bg-secondary" />
-            <span className="h-2 w-8 rounded-full bg-secondary" />
-            <span className="h-2 w-8 rounded-full bg-slate-700" />
-          </div>
-        </div>
+        <OnboardingProgress currentStep={2} totalSteps={4} />
       </header>
 
       <div className="mt-8 space-y-6">


### PR DESCRIPTION
## Summary
- replace the custom progress markup in the timezone, skill profile, and role selection onboarding steps with the shared `OnboardingProgress` component
- configure each step with `totalSteps={4}` and the appropriate `currentStep`, ensuring the role selection screen highlights all four segments

## Testing
- pnpm --filter ./app lint

------
https://chatgpt.com/codex/tasks/task_e_68ce2f69b8588327a4d452c2110c0ab7