### PR TITLE
Add role selection step to onboarding

### DIFF
--- a/app/src/pages/onboarding.tsx
+++ b/app/src/pages/onboarding.tsx
@@ -2,10 +2,16 @@ import { useMemo, useState } from 'react';
 import Head from 'next/head';
 
 import LanguageStep from '@/components/onboarding/LanguageStep';
+import RoleSelectionStep from '@/components/onboarding/RoleSelectionStep';
 import SkillProfileStep from '@/components/onboarding/SkillProfileStep';
 import TimezoneStep from '@/components/onboarding/TimezoneStep';
 
-const STEP_COMPONENTS: Array<() => JSX.Element> = [LanguageStep, TimezoneStep, SkillProfileStep];
+const STEP_COMPONENTS: Array<() => JSX.Element> = [
+  LanguageStep,
+  TimezoneStep,
+  SkillProfileStep,
+  RoleSelectionStep,
+];
 
 export default function OnboardingPage() {
   const [currentStepIndex, setCurrentStepIndex] = useState(0);


### PR DESCRIPTION
## Summary
- import the role selection onboarding step on the Next.js onboarding page
- extend the step component list so the wizard cycles through four steps including role selection

## Testing
- pnpm lint *(fails: existing lint errors in @supermock/server and @supermock/shared)*
- pnpm --filter app lint


------
https://chatgpt.com/codex/tasks/task_e_68ce2e05da4483279bc35ed2ec9c6516