### PR TITLE
feat: navigate after onboarding completion

### DIFF
--- a/app/src/pages/onboarding.tsx
+++ b/app/src/pages/onboarding.tsx
@@ -1,10 +1,12 @@
 import { useMemo, useState } from 'react';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
 
 import LanguageStep from '@/components/onboarding/LanguageStep';
 import RoleSelectionStep from '@/components/onboarding/RoleSelectionStep';
 import SkillProfileStep from '@/components/onboarding/SkillProfileStep';
 import TimezoneStep from '@/components/onboarding/TimezoneStep';
+import { useUserProfile } from '@/store/useUserProfile';
 
 const STEP_COMPONENTS: Array<() => JSX.Element> = [
   LanguageStep,
@@ -15,6 +17,8 @@ const STEP_COMPONENTS: Array<() => JSX.Element> = [
 
 export default function OnboardingPage() {
   const [currentStepIndex, setCurrentStepIndex] = useState(0);
+  const router = useRouter();
+  const profile = useUserProfile((state) => state.profile);
 
   const CurrentStepComponent = useMemo(() => STEP_COMPONENTS[currentStepIndex] ?? LanguageStep, [currentStepIndex]);
   const isFirstStep = currentStepIndex === 0;
@@ -46,7 +50,7 @@ export default function OnboardingPage() {
                   return;
                 }
 
-                // TODO: navigate to the next onboarding step once implemented
+                router.push(profile.role === 'INTERVIEWER' ? '/interviewer' : '/interview');
               }}
             >
               {isLastStep ? 'Continue' : 'Next step'}


### PR DESCRIPTION
## Summary
- load the current onboarding profile and router instance in the onboarding page
- redirect candidates and interviewers to their respective areas after finishing the wizard

## Testing
- pnpm lint *(fails: server lint exits with status 2 due to existing eslint issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ce31213c2c8327af697ec1fead021d