### PR TITLE
Add slot join navigation with slot context

### DIFF
--- a/app/src/pages/slots.tsx
+++ b/app/src/pages/slots.tsx
@@ -534,9 +534,18 @@ interface SlotCardProps {
   showUtc: boolean;
   isFavourite: boolean;
   onToggleFavourite: () => void;
+  onJoin: (slot: Slot) => void;
 }
 
-function SlotCard({ slot, isExpanded, onToggleExpand, showUtc, isFavourite, onToggleFavourite }: SlotCardProps) {
+function SlotCard({
+  slot,
+  isExpanded,
+  onToggleExpand,
+  showUtc,
+  isFavourite,
+  onToggleFavourite,
+  onJoin
+}: SlotCardProps) {
   const startDate = useMemo(() => new Date(slot.start), [slot.start]);
   const endDate = useMemo(() => new Date(slot.end), [slot.end]);
 
@@ -696,7 +705,11 @@ function SlotCard({ slot, isExpanded, onToggleExpand, showUtc, isFavourite, onTo
             </ul>
 
             <div className="flex flex-wrap gap-2">
-              <button className="rounded-lg bg-secondary px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-secondary/90">
+              <button
+                type="button"
+                onClick={() => onJoin(slot)}
+                className="rounded-lg bg-secondary px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-secondary/90"
+              >
                 Присоединиться
               </button>
               <button className="rounded-lg border border-slate-700 px-4 py-2 text-sm font-semibold text-slate-200 hover:border-slate-500">
@@ -912,6 +925,26 @@ export default function SlotDashboardPage() {
       void router.push({ pathname, query });
     },
     [router, slotIntent]
+  );
+
+  const handleJoinSlot = useCallback(
+    (slot: Slot) => {
+      const role = desiredRole;
+      const pathname = role === 'interviewer' ? '/interviewer' : '/interview';
+      const query: Record<string, string | string[]> = {
+        ...slotIntent,
+        role,
+        slotId: slot.id,
+        slotStart: slot.start,
+        slotEnd: slot.end,
+        slotLanguage: slot.language,
+        slotProfessionId: slot.professionId,
+        slotTools: slot.tools
+      };
+
+      void router.push({ pathname, query });
+    },
+    [desiredRole, router, slotIntent]
   );
 
   const hasResults = slotsInActiveTab.length > 0;
@@ -1208,6 +1241,7 @@ export default function SlotDashboardPage() {
                     showUtc={showUtc}
                     isFavourite={favourites.includes(slot.id)}
                     onToggleFavourite={() => toggleFavourite(slot.id)}
+                    onJoin={handleJoinSlot}
                   />
                 ))}
               </div>


### PR DESCRIPTION
## Summary
- allow `SlotCard` to take an `onJoin` callback and invoke it from the join button
- add a `handleJoinSlot` helper that routes to the appropriate page with the selected slot metadata
- pass the join handler to every rendered slot card so joining preserves context

## Testing
- pnpm --filter ./app lint

------
https://chatgpt.com/codex/tasks/task_e_68cf516a67688327b5d18677bf3f2794