### PR TITLE
Protect matching and session routes with auth guards

### DIFF
--- a/server/tests/integration/matching-sessions.auth.test.ts
+++ b/server/tests/integration/matching-sessions.auth.test.ts
@@ -1,0 +1,99 @@
+import fastify, { type FastifyInstance } from 'fastify';
+import { UserRole } from '@prisma/client';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import authPlugin from '../../src/plugins/auth.plugin.js';
+import { registerMatchingRoutes } from '../../src/routes/matching.route.js';
+import { registerRealtimeSessionRoutes } from '../../src/routes/sessions.route.js';
+import type { AppConfig } from '../../src/modules/config.js';
+
+describe('matching & sessions route authorization', () => {
+  let app: FastifyInstance;
+
+  const config: AppConfig = {
+    port: 0,
+    host: '127.0.0.1',
+    corsOrigins: [],
+    logLevel: 'silent',
+    jwt: {
+      secret: 'test-secret',
+      accessTokenTtl: '1h',
+      refreshTokenTtl: '7d'
+    },
+    password: {
+      saltRounds: 10
+    },
+    dailyCo: {
+      enabled: false,
+      apiKey: '',
+      domain: ''
+    }
+  };
+
+  function signToken(role: UserRole) {
+    return app.jwt.sign({
+      id: `user-${role.toLowerCase()}`,
+      email: `${role.toLowerCase()}@example.com`,
+      role,
+      emailVerified: true
+    });
+  }
+
+  beforeAll(async () => {
+    app = fastify({ logger: false });
+    await app.register(authPlugin, { config });
+    registerMatchingRoutes(app, {
+      dailyCo: { service: null, domain: undefined, enabled: false }
+    });
+    registerRealtimeSessionRoutes(app);
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('returns 401 for matching endpoints without authentication', async () => {
+    const response = await app.inject({ method: 'GET', url: '/matching/candidates' });
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('returns 403 for matching endpoints with insufficient role', async () => {
+    const token = signToken(UserRole.CANDIDATE);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/matching/candidates',
+      headers: {
+        authorization: `Bearer ${token}`
+      }
+    });
+
+    expect(response.statusCode).toBe(403);
+  });
+
+  it('returns 401 for sessions endpoints without authentication', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/sessions',
+      payload: { hostId: 'interviewer-1' }
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('returns 403 for sessions endpoints with insufficient role', async () => {
+    const token = signToken(UserRole.CANDIDATE);
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/sessions',
+      headers: {
+        authorization: `Bearer ${token}`
+      },
+      payload: { hostId: 'interviewer-1' }
+    });
+
+    expect(response.statusCode).toBe(403);
+  });
+});

--- a/server/tests/integration/vitest.setup.ts
+++ b/server/tests/integration/vitest.setup.ts
@@ -1,4 +1,33 @@
-import { beforeAll, afterAll } from 'vitest';
+import { beforeAll, afterAll, vi } from 'vitest';
+
+vi.mock('@prisma/client', () => {
+  class PrismaClientMock {
+    $disconnect = vi.fn().mockResolvedValue(undefined);
+    $transaction = vi.fn(async () => Promise.resolve([]));
+    $use = vi.fn();
+    $on = vi.fn();
+  }
+
+  const createEnum = (values: string[]) => {
+    return values.reduce<Record<string, string>>((acc, value) => {
+      acc[value] = value;
+      return acc;
+    }, {});
+  };
+
+  return {
+    PrismaClient: PrismaClientMock,
+    Prisma: {
+      DbNull: Symbol('DbNull'),
+      JsonNull: Symbol('JsonNull'),
+      Null: Symbol('Null')
+    },
+    UserRole: createEnum(['CANDIDATE', 'INTERVIEWER', 'ADMIN']),
+    MatchStatus: createEnum(['QUEUED', 'MATCHED', 'SCHEDULED', 'COMPLETED', 'CANCELLED', 'EXPIRED']),
+    SlotParticipantRole: createEnum(['CANDIDATE', 'INTERVIEWER', 'OBSERVER']),
+    SessionFormat: createEnum(['SYSTEM_DESIGN', 'CODING', 'BEHAVIORAL', 'MIXED'])
+  };
+});
 
 beforeAll(async () => {
   // bootstrap database connections, redis, etc.


### PR DESCRIPTION
## Summary
- add authentication and role checks to matching endpoints, restricting mutations to interviewer/admin roles where appropriate
- secure realtime session routes with corresponding authenticate/authorize pre-handlers for read and write operations
- stub Prisma client in integration setup and add tests covering 401/403 responses for unauthorized access to matching and session APIs

## Testing
- pnpm --filter ./server test:integration

------
https://chatgpt.com/codex/tasks/task_e_68cfb3f1b580832798a0e7fc183f1f29