### PR TITLE
Secure realtime websocket authentication

### DIFF
--- a/server/src/routes/realtime.ws.ts
+++ b/server/src/routes/realtime.ws.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance, FastifyRequest } from 'fastify';
+import type { FastifyJWT } from '@fastify/jwt';
 
 import {
   subscribeToNotifications,
@@ -7,42 +8,178 @@ import {
 } from '../modules/realtime/bus.js';
 import { listInterviewerAvailability } from '../modules/matching.js';
 
-function sendJson(connection: any, payload: unknown) {
+const UNAUTHORIZED_CLOSE_CODE = 1008;
+const UNAUTHORIZED_CLOSE_REASON = 'Unauthorized';
+
+type RealtimeAuthQuery = {
+  token?: string;
+};
+
+type WebSocketLike = {
+  send: (data: string) => void;
+  close: (code?: number, reason?: string) => void;
+  on: (event: 'close', listener: () => void) => void;
+};
+
+type AuthenticatedConnection = {
+  socket?: WebSocketLike | null;
+  user?: FastifyJWT['user'];
+} & Partial<WebSocketLike> & Record<string, unknown>;
+
+function getSocket(connection: AuthenticatedConnection): WebSocketLike | null {
+  if (connection.socket && typeof connection.socket.send === 'function') {
+    return connection.socket;
+  }
+
+  if (
+    typeof connection.send === 'function' &&
+    typeof connection.close === 'function' &&
+    typeof connection.on === 'function'
+  ) {
+    return connection as WebSocketLike;
+  }
+
+  return null;
+}
+
+function sendJson(connection: AuthenticatedConnection, payload: unknown) {
+  const socket = getSocket(connection);
+
+  if (!socket) {
+    return;
+  }
+
   try {
-    connection.socket.send(JSON.stringify(payload));
+    socket.send(JSON.stringify(payload));
   } catch (error) {
     // no-op: avoid crashing due to closed sockets
   }
 }
 
-type SlotsQuery = {
+function closeUnauthorized(connection: AuthenticatedConnection) {
+  const socket = getSocket(connection);
+
+  if (!socket) {
+    return;
+  }
+
+  try {
+    socket.close(UNAUTHORIZED_CLOSE_CODE, UNAUTHORIZED_CLOSE_REASON);
+  } catch {
+    try {
+      socket.close();
+    } catch {
+      // ignore
+    }
+  }
+}
+
+function extractToken(request: FastifyRequest): string | null {
+  const authorizationHeader = request.headers['authorization'];
+  const headerValue = Array.isArray(authorizationHeader) ? authorizationHeader[0] : authorizationHeader;
+
+  if (typeof headerValue === 'string') {
+    const bearerMatch = headerValue.match(/^Bearer\s+(.+)$/i);
+    if (bearerMatch?.[1]) {
+      return bearerMatch[1].trim();
+    }
+
+    const trimmedHeader = headerValue.trim();
+    if (trimmedHeader) {
+      return trimmedHeader;
+    }
+  }
+
+  const { token } = (request as FastifyRequest<{ Querystring: RealtimeAuthQuery }>).query ?? {};
+
+  if (typeof token === 'string' && token.trim()) {
+    return token.trim();
+  }
+
+  return null;
+}
+
+async function verifyToken(app: FastifyInstance, token: string): Promise<FastifyJWT['user']> {
+  const fastifyWithJwt = app as FastifyInstance & {
+    jwt?: {
+      verify: (
+        token: string
+      ) => FastifyJWT['user'] | (FastifyJWT['user'] & Record<string, unknown>) | Promise<FastifyJWT['user'] | (FastifyJWT['user'] & Record<string, unknown>)>;
+    };
+  };
+
+  if (!fastifyWithJwt.jwt || typeof fastifyWithJwt.jwt.verify !== 'function') {
+    throw new Error('JWT plugin is not registered');
+  }
+
+  const decoded = (await fastifyWithJwt.jwt.verify(token)) as FastifyJWT['user'] & Record<string, unknown>;
+
+  return {
+    id: decoded.id,
+    email: decoded.email,
+    role: decoded.role,
+    emailVerified: decoded.emailVerified
+  };
+}
+
+async function authenticateRealtimeConnection(
+  app: FastifyInstance,
+  request: FastifyRequest,
+  connection: AuthenticatedConnection
+): Promise<FastifyJWT['user'] | null> {
+  const token = extractToken(request);
+
+  if (!token) {
+    request.log.warn('Missing token for websocket connection');
+    closeUnauthorized(connection);
+    return null;
+  }
+
+  try {
+    const user = await verifyToken(app, token);
+
+    (request as FastifyRequest & { user: FastifyJWT['user'] }).user = user;
+    connection.user = user;
+
+    return user;
+  } catch (error) {
+    request.log.error({ err: error }, 'Failed to verify websocket token');
+    closeUnauthorized(connection);
+    return null;
+  }
+}
+
+type SlotsQuery = RealtimeAuthQuery & {
   interviewerId?: string;
 };
 
-type NotificationsQuery = {
-  userId?: string;
-};
+type NotificationsQuery = RealtimeAuthQuery;
 
-type SessionQuery = {
+type SessionQuery = RealtimeAuthQuery & {
   hostId?: string;
 };
 
 export function registerRealtimeWebsocketRoutes(app: FastifyInstance) {
   app.get('/ws/slots', { websocket: true }, async (connection: any, request) => {
+    const authConnection = connection as AuthenticatedConnection;
     const { interviewerId } = (request as FastifyRequest<{ Querystring: SlotsQuery }>).query ?? {};
+
+    if (!(await authenticateRealtimeConnection(app, request, authConnection))) {
+      return;
+    }
 
     if (interviewerId) {
       try {
         const slots = await listInterviewerAvailability(interviewerId);
-        sendJson(connection, { type: 'slots:initial', data: slots });
+        sendJson(authConnection, { type: 'slots:initial', data: slots });
       } catch (error) {
-        sendJson(connection, {
+        sendJson(authConnection, {
           type: 'error',
           message: 'Failed to load availability for interviewer'
         });
       }
     } else {
-      sendJson(connection, { type: 'slots:ready' });
+      sendJson(authConnection, { type: 'slots:ready' });
     }
 
     const unsubscribe = subscribeToSlotUpdates((event) => {
@@ -50,42 +187,52 @@ export function registerRealtimeWebsocketRoutes(app: FastifyInstance) {
         return;
       }
 
-      sendJson(connection, { type: 'slots:update', data: event });
+      sendJson(authConnection, { type: 'slots:update', data: event });
     });
 
-    connection.socket.on('close', () => {
+    getSocket(authConnection)?.on('close', () => {
       unsubscribe();
     });
   });
 
-  app.get('/ws/notifications', { websocket: true }, (connection: any, request) => {
-    const { userId } = (request as FastifyRequest<{ Querystring: NotificationsQuery }>).query ?? {};
+  app.get('/ws/notifications', { websocket: true }, async (connection: any, request) => {
+    const authConnection = connection as AuthenticatedConnection;
+
+    const user = await authenticateRealtimeConnection(app, request, authConnection);
+    if (!user) {
+      return;
+    }
 
     const unsubscribe = subscribeToNotifications((event) => {
-      if (userId && event.notification.userId !== userId) {
+      if (event.notification.userId !== user.id) {
         return;
       }
 
-      sendJson(connection, { type: 'notifications:new', data: event.notification });
+      sendJson(authConnection, { type: 'notifications:new', data: event.notification });
     });
 
-    connection.socket.on('close', () => {
+    getSocket(authConnection)?.on('close', () => {
       unsubscribe();
     });
   });
 
-  app.get('/ws/sessions', { websocket: true }, (connection: any, request) => {
+  app.get('/ws/sessions', { websocket: true }, async (connection: any, request) => {
+    const authConnection = connection as AuthenticatedConnection;
     const { hostId } = (request as FastifyRequest<{ Querystring: SessionQuery }>).query ?? {};
+
+    if (!(await authenticateRealtimeConnection(app, request, authConnection))) {
+      return;
+    }
 
     const unsubscribe = subscribeToSessionUpdates((event) => {
       if (hostId && event.session.hostId !== hostId) {
         return;
       }
 
-      sendJson(connection, { type: 'sessions:update', data: event });
+      sendJson(authConnection, { type: 'sessions:update', data: event });
     });
 
-    connection.socket.on('close', () => {
+    getSocket(authConnection)?.on('close', () => {
       unsubscribe();
     });
   });

--- a/server/tests/integration/realtime.ws.test.ts
+++ b/server/tests/integration/realtime.ws.test.ts
@@ -1,0 +1,253 @@
+import fastify, { type FastifyInstance } from 'fastify';
+import websocket from '@fastify/websocket';
+import WebSocket from 'ws';
+import { AddressInfo } from 'node:net';
+import { setTimeout as delay } from 'node:timers/promises';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import authPlugin from '../../src/plugins/auth.plugin.js';
+import { registerRealtimeWebsocketRoutes } from '../../src/routes/realtime.ws.js';
+import type { AppConfig } from '../../src/modules/config.js';
+import { emitNotification } from '../../src/modules/realtime/bus.js';
+
+type JwtUserPayload = {
+  id: string;
+  email: string;
+  role: 'ADMIN' | 'CANDIDATE' | 'INTERVIEWER';
+  emailVerified: boolean;
+};
+
+const buildTestConfig = (): AppConfig => ({
+  port: 0,
+  host: '127.0.0.1',
+  corsOrigins: [],
+  logLevel: 'silent',
+  jwt: {
+    secret: 'test-secret',
+    accessTokenTtl: '15m',
+    refreshTokenTtl: '7d'
+  },
+  password: {
+    saltRounds: 4
+  },
+  dailyCo: {
+    enabled: false,
+    apiKey: '',
+    domain: ''
+  }
+});
+
+const waitForOpen = (ws: WebSocket) =>
+  new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      ws.close();
+      reject(new Error('Timed out waiting for websocket open'));
+    }, 1000);
+
+    ws.once('open', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+
+    ws.once('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
+
+const waitForClose = (ws: WebSocket) => {
+  if (ws.readyState === WebSocket.CLOSED) {
+    return Promise.resolve({ code: 1000, reason: '' });
+  }
+
+  return new Promise<{ code: number; reason: string }>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      ws.terminate();
+      reject(new Error('Timed out waiting for websocket close'));
+    }, 2000);
+
+    ws.once('close', (code, reasonBuffer) => {
+      clearTimeout(timer);
+      const reason = typeof reasonBuffer === 'string' ? reasonBuffer : reasonBuffer.toString();
+      resolve({ code, reason });
+    });
+
+    ws.once('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
+};
+
+async function waitFor(condition: () => boolean, timeoutMs = 2000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (condition()) {
+      return;
+    }
+
+    await delay(10);
+  }
+
+  throw new Error('Timed out waiting for condition');
+}
+
+describe('Realtime websocket authentication', () => {
+  let app: FastifyInstance;
+  let baseUrl: string;
+
+  const signToken = async (user: JwtUserPayload) => {
+    const fastifyWithJwt = app as FastifyInstance & {
+      jwt?: {
+        sign: (payload: unknown) => string | Promise<string>;
+      };
+    };
+
+    if (!fastifyWithJwt.jwt || typeof fastifyWithJwt.jwt.sign !== 'function') {
+      throw new Error('JWT plugin is not registered');
+    }
+
+    return fastifyWithJwt.jwt.sign({
+      id: user.id,
+      email: user.email,
+      role: user.role,
+      emailVerified: user.emailVerified
+    });
+  };
+
+  beforeEach(async () => {
+    const config = buildTestConfig();
+    app = fastify({ logger: false });
+    await app.register(websocket);
+    await app.register(authPlugin, { config });
+    registerRealtimeWebsocketRoutes(app);
+    await app.listen({ port: 0, host: '127.0.0.1' });
+
+    const address = app.server.address() as AddressInfo;
+    baseUrl = `ws://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('rejects websocket connections without a token', async () => {
+    const ws = new WebSocket(`${baseUrl}/ws/notifications`);
+
+    const closeEvent = await waitForClose(ws);
+
+    expect(closeEvent.code).toBe(1008);
+    expect(closeEvent.reason).toBe('Unauthorized');
+  });
+
+  it('only delivers notifications for the authenticated user', async () => {
+    const [candidateToken, interviewerToken] = await Promise.all([
+      signToken({
+        id: 'user-candidate',
+        email: 'candidate@example.com',
+        role: 'CANDIDATE',
+        emailVerified: true
+      }),
+      signToken({
+        id: 'user-interviewer',
+        email: 'interviewer@example.com',
+        role: 'INTERVIEWER',
+        emailVerified: true
+      })
+    ]);
+
+    const candidateSocket = new WebSocket(
+      `${baseUrl}/ws/notifications?token=${encodeURIComponent(candidateToken)}`
+    );
+    const interviewerSocket = new WebSocket(`${baseUrl}/ws/notifications`, {
+      headers: {
+        Authorization: `Bearer ${interviewerToken}`
+      }
+    });
+
+    await Promise.all([waitForOpen(candidateSocket), waitForOpen(interviewerSocket)]);
+
+    const candidateMessages: unknown[] = [];
+    const interviewerMessages: unknown[] = [];
+    const socketClosures: Array<{ socket: 'candidate' | 'interviewer'; code: number; reason: string }> = [];
+
+    candidateSocket.on('message', (data) => {
+      candidateMessages.push(JSON.parse(data.toString()));
+    });
+
+    interviewerSocket.on('message', (data) => {
+      interviewerMessages.push(JSON.parse(data.toString()));
+    });
+
+    candidateSocket.on('close', (code, reasonBuffer) => {
+      const reason = typeof reasonBuffer === 'string' ? reasonBuffer : reasonBuffer.toString();
+      socketClosures.push({ socket: 'candidate', code, reason });
+    });
+
+    interviewerSocket.on('close', (code, reasonBuffer) => {
+      const reason = typeof reasonBuffer === 'string' ? reasonBuffer : reasonBuffer.toString();
+      socketClosures.push({ socket: 'interviewer', code, reason });
+    });
+
+    const closeSockets = async () => {
+      const pending: Array<Promise<unknown>> = [];
+
+      if (candidateSocket.readyState !== WebSocket.CLOSED) {
+        pending.push(waitForClose(candidateSocket));
+        candidateSocket.close();
+      }
+
+      if (interviewerSocket.readyState !== WebSocket.CLOSED) {
+        pending.push(waitForClose(interviewerSocket));
+        interviewerSocket.close();
+      }
+
+      await Promise.all(pending);
+    };
+
+    try {
+      emitNotification({
+        notification: {
+          id: 'notif-1',
+          userId: 'user-candidate',
+          type: 'test',
+          channel: null,
+          payload: { message: 'candidate' },
+          readAt: null,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          metadata: null
+        }
+      });
+
+      await waitFor(() => candidateMessages.length === 1);
+      await delay(20);
+      expect(interviewerMessages.length).toBe(0);
+      expect(socketClosures).toEqual([]);
+
+      emitNotification({
+        notification: {
+          id: 'notif-2',
+          userId: 'user-interviewer',
+          type: 'test',
+          channel: null,
+          payload: { message: 'interviewer' },
+          readAt: null,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+          metadata: null
+        }
+      });
+
+      await waitFor(() => interviewerMessages.length === 1);
+      await delay(20);
+      expect(candidateMessages.length).toBe(1);
+
+      expect(candidateMessages).toHaveLength(1);
+      expect(interviewerMessages).toHaveLength(1);
+      expect(socketClosures).toEqual([]);
+    } finally {
+      await closeSockets();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- verify JWT tokens during websocket upgrades, supporting query string and header tokens while storing the authenticated user on the connection
- reuse the authenticated context to filter notification broadcasts to the correct user and operate slot/session subscriptions with authenticated sockets
- add integration coverage to reject unauthorized websocket connections and ensure notifications are scoped to the authenticated user

## Testing
- pnpm test:integration
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cfb3ff4e888327a308b3bd61ebdc40