### PR TITLE
Add configurable rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,8 @@ SERVER_HOST=0.0.0.0
 CORS_ORIGIN=https://supermock.ru,https://app.supermock.ru
 RATE_LIMIT_MAX=100
 RATE_LIMIT_WINDOW=1 minute
+RATE_LIMIT_CRITICAL_MAX=50
+RATE_LIMIT_CRITICAL_WINDOW=1 minute
 SESSION_SECRET=change-me
 
 # ===== Mailer =====

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,6 +334,9 @@ importers:
       '@fastify/jwt':
         specifier: ^10.0.0
         version: 10.0.0
+      '@fastify/rate-limit':
+        specifier: ^10.3.0
+        version: 10.3.0
       '@fastify/websocket':
         specifier: ^11.0.0
         version: 11.2.0
@@ -1292,6 +1295,14 @@ packages:
     dependencies:
       '@fastify/forwarded': 3.0.0
       ipaddr.js: 2.2.0
+    dev: false
+
+  /@fastify/rate-limit@10.3.0:
+    resolution: {integrity: sha512-eIGkG9XKQs0nyynatApA3EVrojHOuq4l6fhB4eeCk4PIOeadvOJz9/4w3vGI44Go17uaXOWEcPkaD8kuKm7g6Q==}
+    dependencies:
+      '@lukeed/ms': 2.0.2
+      fastify-plugin: 5.0.1
+      toad-cache: 3.7.0
     dev: false
 
   /@fastify/websocket@11.2.0:

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@fastify/cors": "^10.0.0",
     "@fastify/jwt": "^10.0.0",
+    "@fastify/rate-limit": "^10.3.0",
     "@fastify/websocket": "^11.0.0",
     "@prisma/client": "^5.12.1",
     "bcryptjs": "^2.4.3",
@@ -35,8 +36,8 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.29.1",
-    "prisma": "^5.12.1",
     "prettier": "^3.2.5",
+    "prisma": "^5.12.1",
     "tsup": "^8.0.1",
     "tsx": "^4.7.2",
     "typescript": "^5.4.5",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -4,6 +4,7 @@ import cors from '@fastify/cors';
 
 import { buildConfig } from './modules/config.js';
 import authPlugin from './plugins/auth.plugin.js';
+import rateLimitPlugin from './plugins/rate-limit.plugin.js';
 import { registerCoreRoutes } from './routes/core.route.js';
 import { registerHealthRoute } from './routes/health.route.js';
 import { registerMatchingRoutes } from './routes/matching.route.js';
@@ -38,6 +39,7 @@ async function bootstrap() {
     credentials: true
   });
 
+  await app.register(rateLimitPlugin, { config });
   await app.register(websocket);
   await app.register(authPlugin, { config });
 

--- a/server/src/plugins/rate-limit.plugin.ts
+++ b/server/src/plugins/rate-limit.plugin.ts
@@ -1,0 +1,67 @@
+import type { FastifyPluginAsync } from 'fastify';
+import rateLimit from '@fastify/rate-limit';
+
+import type { AppConfig } from '../modules/config.js';
+import { getRequestIp } from '../utils/request-ip.js';
+
+declare module 'fastify' {
+  interface FastifyRouteConfig {
+    rateLimit?: {
+      max: number;
+      timeWindow: string;
+    } | false;
+  }
+}
+
+const rateLimitPlugin: FastifyPluginAsync<{ config: AppConfig }> = async (app, opts) => {
+  const { global, critical } = opts.config.rateLimit;
+
+  app.addHook('onRoute', (routeOptions) => {
+    if (typeof routeOptions.url !== 'string') {
+      return;
+    }
+
+    if (routeOptions.config?.rateLimit === false) {
+      return;
+    }
+
+    if (!routeOptions.url.startsWith('/auth') && !routeOptions.url.startsWith('/matching')) {
+      return;
+    }
+
+    if (routeOptions.config?.rateLimit) {
+      return;
+    }
+
+    routeOptions.config = {
+      ...(routeOptions.config ?? {}),
+      rateLimit: {
+        max: critical.max,
+        timeWindow: critical.timeWindow
+      }
+    };
+  });
+
+  await app.register(rateLimit, {
+    global: true,
+    max: global.max,
+    timeWindow: global.timeWindow,
+    keyGenerator: (request) => getRequestIp(request)
+  });
+};
+
+function exposePlugin<T extends Record<string, any>>(fn: FastifyPluginAsync<T>, name: string): FastifyPluginAsync<T> {
+  const plugin = fn as FastifyPluginAsync<T> & {
+    default?: FastifyPluginAsync<T>;
+    [key: symbol]: unknown;
+  };
+
+  plugin[Symbol.for('skip-override')] = true;
+  plugin[Symbol.for('fastify.display-name')] = name;
+  plugin[Symbol.for('plugin-meta')] = { name };
+  plugin.default = plugin;
+
+  return plugin;
+}
+
+export default exposePlugin(rateLimitPlugin, 'rate-limit-plugin');

--- a/server/src/routes/auth.route.ts
+++ b/server/src/routes/auth.route.ts
@@ -14,6 +14,7 @@ import {
   getUserProfile
 } from '../modules/auth.js';
 import { authenticate, authorizeRoles } from '../utils/auth.js';
+import { getRequestIp } from '../utils/request-ip.js';
 
 const signupSchema = z.object({
   email: z.string().trim().toLowerCase().email(),
@@ -56,7 +57,7 @@ const roleMap: Record<'candidate' | 'interviewer', UserRole> = {
 function extractMetadata(request: FastifyRequest): RequestMetadata {
   const userAgentHeader = request.headers['user-agent'];
   return {
-    ipAddress: request.ip,
+    ipAddress: getRequestIp(request),
     userAgent: typeof userAgentHeader === 'string' ? userAgentHeader : undefined
   };
 }

--- a/server/src/utils/request-ip.ts
+++ b/server/src/utils/request-ip.ts
@@ -1,0 +1,41 @@
+import type { FastifyRequest } from 'fastify';
+
+type HeaderValue = string | string[] | undefined;
+
+function extractFirst(value: HeaderValue): string | null {
+  if (!value) {
+    return null;
+  }
+
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const result = extractFirst(entry);
+      if (result) {
+        return result;
+      }
+    }
+    return null;
+  }
+
+  const first = value.split(',')[0]?.trim();
+  return first && first.length > 0 ? first : null;
+}
+
+export function getRequestIp(request: FastifyRequest): string {
+  const forwardedFor = extractFirst(request.headers['x-forwarded-for']);
+  if (forwardedFor) {
+    return forwardedFor;
+  }
+
+  const realIp = extractFirst(request.headers['x-real-ip']);
+  if (realIp) {
+    return realIp;
+  }
+
+  const remoteAddress = typeof request.socket?.remoteAddress === 'string' ? request.socket.remoteAddress : null;
+  if (remoteAddress) {
+    return remoteAddress;
+  }
+
+  return request.ip;
+}

--- a/server/tests/integration/rate-limit.test.ts
+++ b/server/tests/integration/rate-limit.test.ts
@@ -1,0 +1,115 @@
+import fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { AppConfig } from '../../src/modules/config.js';
+import rateLimitPlugin from '../../src/plugins/rate-limit.plugin.js';
+
+describe('Rate limiting for critical routes', () => {
+  let app: FastifyInstance;
+  let config: AppConfig;
+
+  const buildConfig = (): AppConfig => ({
+    port: 0,
+    host: '127.0.0.1',
+    corsOrigins: [],
+    logLevel: 'silent',
+    jwt: {
+      secret: 'test-secret',
+      accessTokenTtl: '15m',
+      refreshTokenTtl: '7d'
+    },
+    password: {
+      saltRounds: 4
+    },
+    dailyCo: {
+      enabled: false,
+      apiKey: '',
+      domain: ''
+    },
+    rateLimit: {
+      global: {
+        max: 100,
+        timeWindow: '1 minute'
+      },
+      critical: {
+        max: 2,
+        timeWindow: '1 minute'
+      }
+    }
+  });
+
+  beforeEach(async () => {
+    config = buildConfig();
+    app = fastify({ logger: false });
+    await app.register(rateLimitPlugin, { config });
+
+    app.post('/auth/test', async () => ({ ok: true }));
+    app.get('/matching/test', async () => ({ ok: true }));
+
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('returns 429 when auth routes exceed the configured limit for an IP address', async () => {
+    const headers = { 'x-forwarded-for': '203.0.113.10' };
+
+    for (let attempt = 0; attempt < config.rateLimit.critical.max; attempt += 1) {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/auth/test',
+        headers
+      });
+
+      expect(response.statusCode).toBe(200);
+    }
+
+    const blocked = await app.inject({
+      method: 'POST',
+      url: '/auth/test',
+      headers
+    });
+
+    expect(blocked.statusCode).toBe(429);
+
+    const differentIp = await app.inject({
+      method: 'POST',
+      url: '/auth/test',
+      headers: { 'x-forwarded-for': '198.51.100.42' }
+    });
+
+    expect(differentIp.statusCode).toBe(200);
+  });
+
+  it('returns 429 when matching routes exceed the configured limit for an IP address', async () => {
+    const headers = { 'x-forwarded-for': '203.0.113.20' };
+
+    for (let attempt = 0; attempt < config.rateLimit.critical.max; attempt += 1) {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/matching/test',
+        headers
+      });
+
+      expect(response.statusCode).toBe(200);
+    }
+
+    const blocked = await app.inject({
+      method: 'GET',
+      url: '/matching/test',
+      headers
+    });
+
+    expect(blocked.statusCode).toBe(429);
+
+    const differentIp = await app.inject({
+      method: 'GET',
+      url: '/matching/test',
+      headers: { 'x-forwarded-for': '198.51.100.99' }
+    });
+
+    expect(differentIp.statusCode).toBe(200);
+  });
+});

--- a/server/tests/unit/config.test.ts
+++ b/server/tests/unit/config.test.ts
@@ -9,6 +9,16 @@ describe('buildConfig', () => {
     expect(config.host).toBe('0.0.0.0');
     expect(config.corsOrigins).toEqual(['http://localhost:3000', 'http://localhost:3001']);
     expect(config.logLevel).toBe('info');
+    expect(config.rateLimit).toEqual({
+      global: {
+        max: 100,
+        timeWindow: '1 minute'
+      },
+      critical: {
+        max: 100,
+        timeWindow: '1 minute'
+      }
+    });
   });
 
   it('parses comma separated cors origins', () => {


### PR DESCRIPTION
## Summary
- register a Fastify rate limiting plugin backed by environment-driven defaults and critical route overrides
- extract client IPs from forwarding headers for auth metadata and update environment documentation
- cover rate limit behaviour with integration and unit tests, including 429 responses on auth and matching endpoints

## Testing
- pnpm --filter @supermock/server test:unit
- pnpm --filter @supermock/server test:integration

------
https://chatgpt.com/codex/tasks/task_e_68cfb42803a8832785d12f7cb289770c