### PR TITLE
Add matching proxy handlers and improve API routing

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -29,6 +29,21 @@ import type { OnboardingProfileDraftPayload, OnboardingProfileDraftResponse } fr
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';
 const USE_NEXT_API = typeof window !== 'undefined'; // Use Next.js API routes on client side
+const NEXT_API_PROXY_PREFIXES = [
+  '/matching/overview',
+  '/matching/candidates',
+  '/matching/interviewers',
+  '/matching/availability',
+  '/matching/sessions/recent',
+  '/matching/requests',
+  '/matching/slots'
+] as const;
+
+function shouldUseNextApi(path: string) {
+  return NEXT_API_PROXY_PREFIXES.some((prefix) =>
+    path === prefix || path.startsWith(`${prefix}/`) || path.startsWith(`${prefix}?`)
+  );
+}
 
 async function request<T>(path: string, init?: RequestInit): Promise<T> {
   const headers: Record<string, string> = {};
@@ -54,8 +69,8 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
     }
   }
   
-  // Use Next.js API routes on client side for better CORS handling
-  const baseUrl = USE_NEXT_API && path.startsWith('/matching/') ? '/api' : API_BASE_URL;
+  // Use Next.js API routes on client side for better CORS handling when a proxy exists
+  const baseUrl = USE_NEXT_API && shouldUseNextApi(path) ? '/api' : API_BASE_URL;
   
   const response = await fetch(`${baseUrl}${path}`, {
     headers: {

--- a/app/src/pages/api/matching/_proxyUtils.ts
+++ b/app/src/pages/api/matching/_proxyUtils.ts
@@ -1,0 +1,45 @@
+import type { NextApiRequest } from 'next';
+
+export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:4000';
+const METHODS_WITHOUT_BODY = new Set(['GET', 'HEAD', 'OPTIONS']);
+
+function getHeaderValue(value: string | string[] | undefined) {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+
+  return value;
+}
+
+export function createProxyHeaders(req: NextApiRequest) {
+  const headers: Record<string, string> = {};
+  const authorization = getHeaderValue(req.headers.authorization);
+
+  if (authorization) {
+    headers['Authorization'] = authorization;
+    console.log('Forwarding auth header:', `${authorization.substring(0, 20)}...`);
+  } else {
+    console.log('No authorization header found in request:', Object.keys(req.headers));
+  }
+
+  const contentType = getHeaderValue(req.headers['content-type']);
+  if (contentType) {
+    headers['Content-Type'] = contentType;
+  }
+
+  return headers;
+}
+
+export function getRequestBody(req: NextApiRequest, method: string) {
+  if (METHODS_WITHOUT_BODY.has(method)) {
+    return undefined;
+  }
+
+  const { body } = req;
+
+  if (body === undefined || body === null) {
+    return undefined;
+  }
+
+  return typeof body === 'string' ? body : JSON.stringify(body);
+}

--- a/app/src/pages/api/matching/requests/[id]/index.ts
+++ b/app/src/pages/api/matching/requests/[id]/index.ts
@@ -1,0 +1,39 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { API_BASE_URL, createProxyHeaders, getRequestBody } from '../../_proxyUtils';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const method = req.method ?? 'GET';
+  const { id } = req.query;
+
+  if (!id || typeof id !== 'string') {
+    return res.status(400).json({ error: 'Request ID is required' });
+  }
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/matching/requests/${id}`, {
+      method,
+      headers: createProxyHeaders(req),
+      body: getRequestBody(req, method)
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return res.status(response.status).json({
+        error: errorText || `API request failed with status ${response.status}`
+      });
+    }
+
+    if (response.status === 204) {
+      return res.status(204).end();
+    }
+
+    const data = await response.json();
+    return res.status(response.status).json(data);
+  } catch (error) {
+    console.error('API proxy error:', error);
+    return res.status(500).json({
+      error: 'Failed to proxy API request'
+    });
+  }
+}

--- a/app/src/pages/api/matching/requests/[id]/previews.ts
+++ b/app/src/pages/api/matching/requests/[id]/previews.ts
@@ -1,0 +1,39 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { API_BASE_URL, createProxyHeaders, getRequestBody } from '../../_proxyUtils';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const method = req.method ?? 'GET';
+  const { id } = req.query;
+
+  if (!id || typeof id !== 'string') {
+    return res.status(400).json({ error: 'Request ID is required' });
+  }
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/matching/requests/${id}/previews`, {
+      method,
+      headers: createProxyHeaders(req),
+      body: getRequestBody(req, method)
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return res.status(response.status).json({
+        error: errorText || `API request failed with status ${response.status}`
+      });
+    }
+
+    if (response.status === 204) {
+      return res.status(204).end();
+    }
+
+    const data = await response.json();
+    return res.status(response.status).json(data);
+  } catch (error) {
+    console.error('API proxy error:', error);
+    return res.status(500).json({
+      error: 'Failed to proxy API request'
+    });
+  }
+}

--- a/app/src/pages/api/matching/requests/[id]/schedule.ts
+++ b/app/src/pages/api/matching/requests/[id]/schedule.ts
@@ -1,0 +1,39 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { API_BASE_URL, createProxyHeaders, getRequestBody } from '../../_proxyUtils';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const method = req.method ?? 'GET';
+  const { id } = req.query;
+
+  if (!id || typeof id !== 'string') {
+    return res.status(400).json({ error: 'Request ID is required' });
+  }
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/matching/requests/${id}/schedule`, {
+      method,
+      headers: createProxyHeaders(req),
+      body: getRequestBody(req, method)
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return res.status(response.status).json({
+        error: errorText || `API request failed with status ${response.status}`
+      });
+    }
+
+    if (response.status === 204) {
+      return res.status(204).end();
+    }
+
+    const data = await response.json();
+    return res.status(response.status).json(data);
+  } catch (error) {
+    console.error('API proxy error:', error);
+    return res.status(500).json({
+      error: 'Failed to proxy API request'
+    });
+  }
+}

--- a/app/src/pages/api/matching/requests/index.ts
+++ b/app/src/pages/api/matching/requests/index.ts
@@ -1,0 +1,34 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { API_BASE_URL, createProxyHeaders, getRequestBody } from '../_proxyUtils';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const method = req.method ?? 'GET';
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/matching/requests`, {
+      method,
+      headers: createProxyHeaders(req),
+      body: getRequestBody(req, method)
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return res.status(response.status).json({
+        error: errorText || `API request failed with status ${response.status}`
+      });
+    }
+
+    if (response.status === 204) {
+      return res.status(204).end();
+    }
+
+    const data = await response.json();
+    return res.status(response.status).json(data);
+  } catch (error) {
+    console.error('API proxy error:', error);
+    return res.status(500).json({
+      error: 'Failed to proxy API request'
+    });
+  }
+}

--- a/app/src/pages/api/matching/slots/[id]/index.ts
+++ b/app/src/pages/api/matching/slots/[id]/index.ts
@@ -1,0 +1,39 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { API_BASE_URL, createProxyHeaders, getRequestBody } from '../../_proxyUtils';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const method = req.method ?? 'GET';
+  const { id } = req.query;
+
+  if (!id || typeof id !== 'string') {
+    return res.status(400).json({ error: 'Slot ID is required' });
+  }
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/matching/slots/${id}`, {
+      method,
+      headers: createProxyHeaders(req),
+      body: getRequestBody(req, method)
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return res.status(response.status).json({
+        error: errorText || `API request failed with status ${response.status}`
+      });
+    }
+
+    if (response.status === 204) {
+      return res.status(204).end();
+    }
+
+    const data = await response.json();
+    return res.status(response.status).json(data);
+  } catch (error) {
+    console.error('API proxy error:', error);
+    return res.status(500).json({
+      error: 'Failed to proxy API request'
+    });
+  }
+}

--- a/app/src/pages/api/matching/slots/[id]/join.ts
+++ b/app/src/pages/api/matching/slots/[id]/join.ts
@@ -1,0 +1,39 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { API_BASE_URL, createProxyHeaders, getRequestBody } from '../../_proxyUtils';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const method = req.method ?? 'GET';
+  const { id } = req.query;
+
+  if (!id || typeof id !== 'string') {
+    return res.status(400).json({ error: 'Slot ID is required' });
+  }
+
+  try {
+    const response = await fetch(`${API_BASE_URL}/matching/slots/${id}/join`, {
+      method,
+      headers: createProxyHeaders(req),
+      body: getRequestBody(req, method)
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return res.status(response.status).json({
+        error: errorText || `API request failed with status ${response.status}`
+      });
+    }
+
+    if (response.status === 204) {
+      return res.status(204).end();
+    }
+
+    const data = await response.json();
+    return res.status(response.status).json(data);
+  } catch (error) {
+    console.error('API proxy error:', error);
+    return res.status(500).json({
+      error: 'Failed to proxy API request'
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- route client-side requests through Next.js only for known proxy prefixes and fall back to the API host otherwise
- add shared helpers for matching API proxy handlers to forward headers and request bodies
- implement missing proxies for match requests and slots endpoints so they relay authorization and payloads

## Testing
- pnpm --filter ./app lint *(fails: Definition for rule '@typescript-eslint/no-explicit-any' was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc8cf99788327b42350530319b6ad