### PR TITLE
Add user data export and account management UI

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -46,7 +46,11 @@ function shouldUseNextApi(path: string) {
   );
 }
 
-async function request<T>(path: string, init?: RequestInit): Promise<T> {
+type RequestOptions = {
+  responseType?: 'json' | 'blob';
+};
+
+async function request<T>(path: string, init?: RequestInit, options?: RequestOptions): Promise<T> {
   const headers: Record<string, string> = {};
   
   // Only set Content-Type for requests with a body
@@ -88,6 +92,10 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
 
   if (response.status === 204) {
     return undefined as T;
+  }
+
+  if (options?.responseType === 'blob') {
+    return (await response.blob()) as T;
   }
 
   return (await response.json()) as T;
@@ -332,4 +340,28 @@ export function fetchInterviewAiInsights(matchId: string) {
 
 export function fetchPlatformStats() {
   return request<PlatformStatsDto>('/analytics/overview');
+}
+
+export function exportUserData(userId: string, options?: { format?: 'json' | 'zip' }) {
+  const search = new URLSearchParams();
+  const format = options?.format ?? 'json';
+
+  if (format === 'zip') {
+    search.set('format', 'zip');
+  }
+
+  const query = search.toString();
+  const path = `/users/${userId}/export${query ? `?${query}` : ''}`;
+
+  return request<Blob>(path, undefined, { responseType: 'blob' });
+}
+
+export function deleteAccount(
+  userId: string,
+  payload: { password?: string; token?: string }
+) {
+  return request<void>(`/users/${userId}`, {
+    method: 'DELETE',
+    body: JSON.stringify(payload)
+  });
 }

--- a/app/src/pages/profile.tsx
+++ b/app/src/pages/profile.tsx
@@ -1,0 +1,256 @@
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+
+import { deleteAccount, exportUserData } from '@/lib/api';
+import { useAuth } from '@/store/useAuth';
+
+export default function ProfilePage() {
+  const router = useRouter();
+  const user = useAuth((state) => state.user);
+  const isAuthenticated = useAuth((state) => state.isAuthenticated);
+
+  const [isExporting, setIsExporting] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [password, setPassword] = useState('');
+  const [token, setToken] = useState('');
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const handleExport = async () => {
+    if (!user) {
+      setExportError('Авторизуйтесь, чтобы выгрузить данные.');
+      return;
+    }
+
+    setIsExporting(true);
+    setExportError(null);
+
+    try {
+      const blob = await exportUserData(user.id);
+      const mimeType = blob.type?.toLowerCase?.() ?? 'application/json';
+      const extension = mimeType.includes('gzip') ? 'json.gz' : 'json';
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      const filename = `supermock-user-export-${timestamp}.${extension}`;
+
+      const objectUrl = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = objectUrl;
+      anchor.download = filename;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      URL.revokeObjectURL(objectUrl);
+    } catch (error) {
+      setExportError(error instanceof Error ? error.message : 'Не удалось выгрузить данные');
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const openDeleteModal = () => {
+    setDeleteError(null);
+    setPassword('');
+    setToken('');
+    setShowDeleteModal(true);
+  };
+
+  const closeDeleteModal = () => {
+    if (!isDeleting) {
+      setShowDeleteModal(false);
+    }
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!user) {
+      setDeleteError('Не удалось определить пользователя.');
+      return;
+    }
+
+    const passwordValue = password.trim();
+    const tokenValue = token.trim();
+
+    if (!passwordValue && !tokenValue) {
+      setDeleteError('Введите пароль или одноразовый токен.');
+      return;
+    }
+
+    setIsDeleting(true);
+    setDeleteError(null);
+
+    try {
+      await deleteAccount(user.id, {
+        password: passwordValue || undefined,
+        token: tokenValue || undefined
+      });
+
+      setShowDeleteModal(false);
+      setPassword('');
+      setToken('');
+      useAuth.getState().logout();
+      await router.replace('/');
+    } catch (error) {
+      setDeleteError(error instanceof Error ? error.message : 'Не удалось удалить аккаунт');
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <>
+      <Head>
+        <title>Профиль — SuperMock</title>
+      </Head>
+      <main className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-4 py-10">
+        <header className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-lg shadow-slate-950/40">
+          <h1 className="text-2xl font-semibold text-white">Профиль</h1>
+          {isAuthenticated && user ? (
+            <p className="mt-2 text-sm text-slate-400">Вход выполнен для {user.email}</p>
+          ) : (
+            <p className="mt-2 text-sm text-slate-400">Авторизуйтесь, чтобы управлять личными данными.</p>
+          )}
+        </header>
+
+        <section className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-lg shadow-slate-950/40">
+          <h2 className="text-lg font-semibold text-white">Управление данными</h2>
+          <p className="mt-2 text-sm text-slate-400">
+            Вы можете выгрузить копию профиля, включая анкеты кандидата и интервьюера, а также сохранённые уведомления.
+          </p>
+
+          <div className="mt-4 flex flex-wrap items-center gap-3">
+            <button
+              type="button"
+              onClick={handleExport}
+              disabled={!user || isExporting}
+              className="inline-flex items-center gap-2 rounded-md bg-secondary px-4 py-2 text-sm font-semibold text-slate-950 shadow shadow-secondary/40 transition hover:bg-secondary/90 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isExporting ? 'Формируем архив…' : 'Выгрузить данные'}
+            </button>
+            <span className="text-xs text-slate-500">
+              Файл будет сохранён в формате JSON. Для архива укажите параметр «format=zip».
+            </span>
+          </div>
+
+          {exportError && (
+            <p className="mt-3 text-sm text-red-400" role="alert">
+              {exportError}
+            </p>
+          )}
+
+          <div className="mt-6 rounded-lg border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-100">
+            <p className="font-semibold">Удаление аккаунта</p>
+            <p className="mt-2 text-amber-100/80">
+              Все данные, включая анкеты и уведомления, будут безвозвратно удалены. Для подтверждения требуется пароль или
+              одноразовый токен подтверждения.
+            </p>
+            <div className="mt-4 flex flex-wrap gap-3">
+              <button
+                type="button"
+                onClick={openDeleteModal}
+                disabled={!user}
+                className="inline-flex items-center gap-2 rounded-md border border-red-500/70 px-4 py-2 text-sm font-semibold text-red-200 transition hover:bg-red-500/10 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                Удалить аккаунт
+              </button>
+              <span className="text-xs text-amber-200/80">
+                После подтверждения токены будут отозваны, активные сессии завершатся.
+              </span>
+            </div>
+          </div>
+        </section>
+
+        {showDeleteModal && (
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/70 backdrop-blur-sm"
+            onClick={closeDeleteModal}
+          >
+            <div
+              className="w-full max-w-md rounded-xl border border-slate-700 bg-slate-900 p-6 shadow-2xl shadow-slate-950/70"
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="delete-account-title"
+              onClick={(event) => event.stopPropagation()}
+            >
+              <h3 id="delete-account-title" className="text-lg font-semibold text-white">
+                Подтверждение удаления
+              </h3>
+              <p className="mt-2 text-sm text-slate-400">
+                Подтвердите, что хотите удалить учётную запись. Укажите текущий пароль или одноразовый токен подтверждения.
+              </p>
+
+              <div className="mt-4 space-y-4">
+                <div>
+                  <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="delete-password">
+                    Пароль
+                  </label>
+                  <input
+                    id="delete-password"
+                    type="password"
+                    autoComplete="current-password"
+                    className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white shadow-inner shadow-slate-950/40 focus:border-secondary focus:outline-none focus:ring-2 focus:ring-secondary/60"
+                    value={password}
+                    onChange={(event) => {
+                      setPassword(event.target.value);
+                      if (deleteError) {
+                        setDeleteError(null);
+                      }
+                    }}
+                    placeholder="Введите пароль"
+                    disabled={isDeleting}
+                  />
+                </div>
+
+                <div>
+                  <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="delete-token">
+                    Одноразовый токен
+                  </label>
+                  <input
+                    id="delete-token"
+                    type="text"
+                    className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white shadow-inner shadow-slate-950/40 focus:border-secondary focus:outline-none focus:ring-2 focus:ring-secondary/60"
+                    value={token}
+                    onChange={(event) => {
+                      setToken(event.target.value);
+                      if (deleteError) {
+                        setDeleteError(null);
+                      }
+                    }}
+                    placeholder="Вставьте полученный токен"
+                    disabled={isDeleting}
+                  />
+                  <p className="mt-1 text-xs text-slate-500">Можно заполнить только одно поле: пароль или токен.</p>
+                </div>
+              </div>
+
+              {deleteError && (
+                <p className="mt-3 text-sm text-red-400" role="alert">
+                  {deleteError}
+                </p>
+              )}
+
+              <div className="mt-6 flex justify-end gap-3">
+                <button
+                  type="button"
+                  onClick={closeDeleteModal}
+                  disabled={isDeleting}
+                  className="rounded-md border border-slate-600 px-4 py-2 text-sm font-medium text-slate-200 transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  Отмена
+                </button>
+                <button
+                  type="button"
+                  onClick={handleConfirmDelete}
+                  disabled={isDeleting}
+                  className="rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white shadow shadow-red-900/50 transition hover:bg-red-500 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isDeleting ? 'Удаляем…' : 'Удалить аккаунт'}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </main>
+    </>
+  );
+}

--- a/server/src/modules/notifications.ts
+++ b/server/src/modules/notifications.ts
@@ -67,6 +67,15 @@ export async function listNotifications(
   return notifications.map(mapNotification);
 }
 
+export async function listAllNotificationsForUser(userId: string): Promise<NotificationDto[]> {
+  const notifications = await prisma.notification.findMany({
+    where: { userId },
+    orderBy: { createdAt: 'asc' }
+  });
+
+  return notifications.map(mapNotification);
+}
+
 export async function createNotification(
   payload: CreateNotificationPayload
 ): Promise<NotificationDto> {

--- a/server/src/modules/users.ts
+++ b/server/src/modules/users.ts
@@ -1,4 +1,5 @@
 import bcrypt from 'bcryptjs';
+import { createHash } from 'node:crypto';
 import { Prisma, UserRole } from '@prisma/client';
 
 import type {
@@ -21,6 +22,25 @@ type UserWithProfiles = Prisma.UserGetPayload<{
 
 type CandidateProfileRecord = Prisma.CandidateProfileGetPayload<{}>;
 type InterviewerProfileRecord = Prisma.InterviewerProfileGetPayload<{}>;
+
+type UserCredentialsRecord = {
+  id: string;
+  passwordHash: string | null;
+};
+
+export class AccountDeletionError extends Error {
+  statusCode: number;
+
+  constructor(message: string, statusCode = 400) {
+    super(message);
+    this.statusCode = statusCode;
+  }
+}
+
+export type AccountDeletionChallenge = {
+  password?: string;
+  token?: string;
+};
 
 type ListUsersParams = {
   page?: number;
@@ -255,10 +275,78 @@ export async function updateUser(id: string, input: UpdateUserInput): Promise<Us
   return mapUser(user);
 }
 
+export async function getUserCredentials(id: string): Promise<UserCredentialsRecord | null> {
+  const record = await prisma.user.findUnique({
+    where: { id },
+    select: { id: true, passwordHash: true }
+  });
+
+  return record ?? null;
+}
+
+export async function verifyAccountDeletionChallenge(
+  user: UserCredentialsRecord,
+  challenge: AccountDeletionChallenge
+): Promise<'password' | 'token'> {
+  const password = challenge.password?.trim();
+  const token = challenge.token?.trim();
+
+  if (!password && !token) {
+    throw new AccountDeletionError('Password or token is required', 400);
+  }
+
+  if (password) {
+    if (!user.passwordHash) {
+      throw new AccountDeletionError('Password authentication is not available for this account', 400);
+    }
+
+    const isValid = await bcrypt.compare(password, user.passwordHash);
+
+    if (!isValid) {
+      throw new AccountDeletionError('Invalid password', 401);
+    }
+
+    return 'password';
+  }
+
+  if (token) {
+    const tokenHash = createHash('sha256').update(token).digest('hex');
+    const stored = await prisma.passwordResetToken.findUnique({ where: { tokenHash } });
+
+    if (!stored || stored.userId !== user.id) {
+      throw new AccountDeletionError('Invalid or expired token', 401);
+    }
+
+    if (stored.usedAt) {
+      throw new AccountDeletionError('Token already used', 400);
+    }
+
+    if (stored.expiresAt.getTime() <= Date.now()) {
+      throw new AccountDeletionError('Invalid or expired token', 401);
+    }
+
+    await prisma.passwordResetToken.update({
+      where: { id: stored.id },
+      data: { usedAt: new Date() }
+    });
+
+    return 'token';
+  }
+
+  throw new AccountDeletionError('Password or token is required', 400);
+}
+
 export async function deleteUser(id: string): Promise<void> {
-  await prisma.user.delete({ where: { id } });
+  await prisma.$transaction(async (tx) => {
+    await tx.refreshToken.deleteMany({ where: { userId: id } });
+    await tx.notification.deleteMany({ where: { userId: id } });
+    await tx.passwordResetToken.deleteMany({ where: { userId: id } });
+    await tx.emailVerificationToken.deleteMany({ where: { userId: id } });
+    await tx.user.delete({ where: { id } });
+  });
 }
 
 export type {
-  ListUsersParams
+  ListUsersParams,
+  AccountDeletionChallenge
 };

--- a/server/src/routes/users.route.ts
+++ b/server/src/routes/users.route.ts
@@ -1,15 +1,25 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+import { promisify } from 'node:util';
+import { gzip } from 'node:zlib';
 import { UserRole } from '@prisma/client';
 import { z } from 'zod';
+
+import type { UserExportDto } from '../../../shared/src/types/user.js';
 
 import {
   createUser,
   deleteUser,
   getUserById,
+  getUserCredentials,
   listUsers,
-  updateUser
+  updateUser,
+  verifyAccountDeletionChallenge,
+  AccountDeletionError
 } from '../modules/users.js';
+import { listAllNotificationsForUser } from '../modules/notifications.js';
 import { authenticate, authorizeRoles } from '../utils/auth.js';
+
+const gzipAsync = promisify(gzip);
 
 const profileSchema = z.record(z.any()).nullable().optional();
 
@@ -39,6 +49,20 @@ const updateUserSchema = z.object({
 const userIdParamsSchema = z.object({
   id: z.string().min(1)
 });
+
+const exportUserQuerySchema = z.object({
+  format: z.enum(['json', 'zip']).optional()
+});
+
+const deleteUserBodySchema = z
+  .object({
+    password: z.string().trim().min(1).optional(),
+    token: z.string().trim().min(1).optional()
+  })
+  .refine((data) => Boolean(data.password || data.token), {
+    message: 'Password or token is required',
+    path: ['password']
+  });
 
 type AuthenticatedRequest = FastifyRequest & {
   user: {
@@ -76,6 +100,43 @@ export function registerUserRoutes(app: FastifyInstance, options: { passwordSalt
     }
 
     return user;
+  });
+
+  app.get('/users/:id/export', { preHandler: authenticate }, async (request, reply) => {
+    const { id } = userIdParamsSchema.parse(request.params);
+    ensureSelfOrAdmin(request as AuthenticatedRequest, reply, id);
+
+    const query = exportUserQuerySchema.parse(request.query);
+
+    const user = await getUserById(id);
+
+    if (!user) {
+      reply.code(404);
+      throw new Error('User not found');
+    }
+
+    const notifications = await listAllNotificationsForUser(id);
+    const exportData: UserExportDto = {
+      exportedAt: new Date().toISOString(),
+      user,
+      candidateProfile: user.candidateProfile,
+      interviewerProfile: user.interviewerProfile,
+      notifications
+    };
+
+    const format = query.format ?? 'json';
+
+    if (format === 'zip') {
+      const gzipped = await gzipAsync(Buffer.from(JSON.stringify(exportData, null, 2), 'utf-8'));
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+      reply.header('Content-Type', 'application/gzip');
+      reply.header('Content-Disposition', `attachment; filename="user-${id}-export-${timestamp}.json.gz"`);
+      reply.send(gzipped);
+      return reply;
+    }
+
+    reply.header('Content-Disposition', `attachment; filename="user-${id}-export.json"`);
+    return exportData;
   });
 
   app.post('/users', { preHandler: authorizeRoles(UserRole.ADMIN) }, async (request, reply) => {
@@ -118,13 +179,38 @@ export function registerUserRoutes(app: FastifyInstance, options: { passwordSalt
     return user;
   });
 
-  app.delete('/users/:id', { preHandler: authorizeRoles(UserRole.ADMIN) }, async (request, reply) => {
+  app.delete('/users/:id', { preHandler: authenticate }, async (request, reply) => {
     const { id } = userIdParamsSchema.parse(request.params);
+    ensureSelfOrAdmin(request as AuthenticatedRequest, reply, id);
 
     const existing = await getUserById(id);
     if (!existing) {
       reply.code(404);
       throw new Error('User not found');
+    }
+
+    const requester = (request as AuthenticatedRequest).user;
+    const requiresChallenge = requester.role !== UserRole.ADMIN || requester.id === id;
+
+    if (requiresChallenge) {
+      const payload = deleteUserBodySchema.parse(request.body ?? {});
+      const credentials = await getUserCredentials(id);
+
+      if (!credentials) {
+        reply.code(404);
+        throw new Error('User not found');
+      }
+
+      try {
+        await verifyAccountDeletionChallenge(credentials, payload);
+      } catch (error) {
+        if (error instanceof AccountDeletionError) {
+          reply.code(error.statusCode);
+          throw new Error(error.message);
+        }
+
+        throw error;
+      }
     }
 
     await deleteUser(id);

--- a/server/tests/unit/users.data-management.test.ts
+++ b/server/tests/unit/users.data-management.test.ts
@@ -1,0 +1,165 @@
+import { gunzipSync } from 'node:zlib';
+import fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  listUsers: vi.fn(),
+  createUser: vi.fn(),
+  updateUser: vi.fn(),
+  getUserById: vi.fn(),
+  deleteUser: vi.fn(),
+  getUserCredentials: vi.fn(),
+  verifyAccountDeletionChallenge: vi.fn(),
+  listAllNotificationsForUser: vi.fn(),
+  authenticate: vi.fn()
+}));
+
+vi.mock('@prisma/client', () => ({
+  UserRole: {
+    CANDIDATE: 'CANDIDATE',
+    INTERVIEWER: 'INTERVIEWER',
+    ADMIN: 'ADMIN'
+  }
+}));
+
+vi.mock('../../src/modules/users.js', () => ({
+  createUser: mocks.createUser,
+  deleteUser: mocks.deleteUser,
+  getUserById: mocks.getUserById,
+  getUserCredentials: mocks.getUserCredentials,
+  listUsers: mocks.listUsers,
+  updateUser: mocks.updateUser,
+  verifyAccountDeletionChallenge: mocks.verifyAccountDeletionChallenge,
+  AccountDeletionError: class AccountDeletionError extends Error {
+    statusCode: number;
+
+    constructor(message: string, statusCode = 400) {
+      super(message);
+      this.statusCode = statusCode;
+    }
+  }
+}));
+
+vi.mock('../../src/modules/notifications.js', () => ({
+  listAllNotificationsForUser: mocks.listAllNotificationsForUser,
+  listNotifications: vi.fn(),
+  createNotification: vi.fn(),
+  markNotificationsAsRead: vi.fn()
+}));
+
+vi.mock('../../src/utils/auth.js', () => ({
+  authenticate: mocks.authenticate,
+  authorizeRoles: () => async (request: any) => {
+    request.user = { id: 'admin-user', role: 'ADMIN' };
+  }
+}));
+
+import { registerUserRoutes } from '../../src/routes/users.route.js';
+
+const baseUser = {
+  id: 'user_1',
+  email: 'user@example.com',
+  role: 'CANDIDATE',
+  emailVerifiedAt: null,
+  profile: null,
+  avatarUrl: undefined,
+  candidateProfile: null,
+  interviewerProfile: null,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z'
+};
+
+const sampleNotification = {
+  id: 'notif_1',
+  userId: 'user_1',
+  type: 'system.notice',
+  channel: null,
+  payload: undefined,
+  readAt: null,
+  createdAt: '2024-01-02T00:00:00.000Z',
+  updatedAt: '2024-01-02T00:00:00.000Z',
+  metadata: undefined
+};
+
+describe('user data management routes', () => {
+  let app: FastifyInstance;
+
+  beforeEach(async () => {
+    Object.values(mocks).forEach((mockFn) => {
+      mockFn.mockReset();
+    });
+
+    mocks.authenticate.mockImplementation(async (request: any) => {
+      request.user = { id: 'user_1', role: 'CANDIDATE' };
+    });
+
+    mocks.listAllNotificationsForUser.mockResolvedValue([]);
+
+    app = fastify();
+    registerUserRoutes(app, { passwordSaltRounds: 10 });
+    await app.ready();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    vi.clearAllMocks();
+  });
+
+  it('exports sanitized user data as JSON', async () => {
+    mocks.getUserById.mockResolvedValue({ ...baseUser } as any);
+    mocks.listAllNotificationsForUser.mockResolvedValue([{ ...sampleNotification } as any]);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/users/user_1/export'
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json() as any;
+    expect(body.user.id).toBe('user_1');
+    expect(body.notifications).toHaveLength(1);
+    expect(JSON.stringify(body)).not.toContain('passwordHash');
+  });
+
+  it('exports gzipped archive when requested', async () => {
+    mocks.getUserById.mockResolvedValue({ ...baseUser } as any);
+    mocks.listAllNotificationsForUser.mockResolvedValue([{ ...sampleNotification } as any]);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/users/user_1/export?format=zip'
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toContain('application/gzip');
+
+    const rawPayload = (response as any).rawPayload as Buffer | undefined;
+    const buffer = rawPayload ?? Buffer.from(response.body, 'binary');
+    const parsed = JSON.parse(gunzipSync(buffer).toString('utf-8'));
+
+    expect(parsed.user.id).toBe('user_1');
+    expect(parsed.notifications).toHaveLength(1);
+    expect(JSON.stringify(parsed)).not.toContain('passwordHash');
+  });
+
+  it('deletes user after validating challenge', async () => {
+    mocks.getUserById.mockResolvedValue({ ...baseUser } as any);
+    mocks.getUserCredentials.mockResolvedValue({ id: 'user_1', passwordHash: 'hashed-value' });
+    mocks.verifyAccountDeletionChallenge.mockResolvedValue('password');
+    mocks.deleteUser.mockResolvedValue(undefined);
+
+    const response = await app.inject({
+      method: 'DELETE',
+      url: '/users/user_1',
+      payload: { password: 'secret-pass' },
+      headers: { 'content-type': 'application/json' }
+    });
+
+    expect(response.statusCode).toBe(204);
+    expect(mocks.verifyAccountDeletionChallenge).toHaveBeenCalledWith(
+      { id: 'user_1', passwordHash: 'hashed-value' },
+      { password: 'secret-pass', token: undefined }
+    );
+    expect(mocks.deleteUser).toHaveBeenCalledWith('user_1');
+  });
+});

--- a/shared/src/types/user.ts
+++ b/shared/src/types/user.ts
@@ -1,3 +1,5 @@
+import type { NotificationDto } from './realtime.js';
+
 export type UserRole = 'CANDIDATE' | 'INTERVIEWER' | 'ADMIN';
 
 export type ExperienceLevel = 'JUNIOR' | 'MIDDLE' | 'SENIOR';
@@ -94,6 +96,14 @@ export type UserDto = {
   interviewerProfile: InterviewerProfileDto | null;
   createdAt: string;
   updatedAt: string;
+};
+
+export type UserExportDto = {
+  exportedAt: string;
+  user: UserDto;
+  candidateProfile: CandidateProfileDto | null;
+  interviewerProfile: InterviewerProfileDto | null;
+  notifications: NotificationDto[];
 };
 
 export type CreateUserInput = {


### PR DESCRIPTION
## Summary
- add `/users/:id/export` to bundle profile data and notifications as JSON or gzipped archives
- require password or one-time tokens before deleting users while purging refresh tokens and notifications
- expose client API helpers and a `/profile` data management section with export download and deletion confirmation modal
- cover the new flows with unit tests that verify sanitized exports and the happy deletion path

## Testing
- pnpm --filter ./server test:unit

------
https://chatgpt.com/codex/tasks/task_e_68cfe12fbb2483278d766b3bd4f60c3c