### PR TITLE
Add account security session management and profile UI

### DIFF
--- a/app/src/lib/api.ts
+++ b/app/src/lib/api.ts
@@ -24,7 +24,16 @@ import type {
   SessionParticipantDto,
   UpdateRealtimeSessionStatusPayload
 } from '../../../shared/src/types/realtime.js';
-import type { CompleteOnboardingPayload, CompleteOnboardingResponse } from '../../../shared/src/types/user.js';
+import type {
+  CompleteOnboardingPayload,
+  CompleteOnboardingResponse,
+  UserDto
+} from '../../../shared/src/types/user.js';
+import type {
+  AccountSecurityOverviewDto,
+  AuthSessionDto,
+  AuthUserDto
+} from '../../../shared/src/types/auth.js';
 import type { InterviewAiInsightDto, PlatformStatsDto } from '../../../shared/src/types/analytics.js';
 import type { OnboardingProfileDraftPayload, OnboardingProfileDraftResponse } from '@/types/onboarding';
 
@@ -332,4 +341,38 @@ export function fetchInterviewAiInsights(matchId: string) {
 
 export function fetchPlatformStats() {
   return request<PlatformStatsDto>('/analytics/overview');
+}
+
+export function listSessions(userId?: string) {
+  const search = new URLSearchParams();
+
+  if (userId) {
+    search.set('userId', userId);
+  }
+
+  const suffix = search.toString() ? `?${search.toString()}` : '';
+  return request<AccountSecurityOverviewDto>(`/auth/sessions${suffix}`);
+}
+
+export function revokeSession(sessionId: string) {
+  return request<{ revoked: boolean; session: AuthSessionDto }>(`/auth/sessions/${sessionId}`, {
+    method: 'DELETE'
+  });
+}
+
+export function requestEmailVerification(token: string) {
+  return request<{ verified: boolean; user: AuthUserDto; tokens: { accessToken: string } }>(
+    '/auth/verify-email',
+    {
+      method: 'POST',
+      body: JSON.stringify({ token })
+    }
+  );
+}
+
+export function changePassword(userId: string, password: string) {
+  return request<UserDto>(`/users/${userId}`, {
+    method: 'PUT',
+    body: JSON.stringify({ password })
+  });
 }

--- a/app/src/pages/profile.tsx
+++ b/app/src/pages/profile.tsx
@@ -1,0 +1,354 @@
+import { useCallback, useEffect, useState } from 'react';
+import Head from 'next/head';
+
+import { changePassword, listSessions, requestEmailVerification, revokeSession } from '@/lib/api';
+import { useAuth } from '@/store/useAuth';
+import type { AuditLogEntryDto, AuthSessionDto } from '../../../shared/src/types/auth.js';
+
+function formatDate(value: string) {
+  try {
+    return new Intl.DateTimeFormat('ru-RU', {
+      dateStyle: 'medium',
+      timeStyle: 'short'
+    }).format(new Date(value));
+  } catch (error) {
+    return value;
+  }
+}
+
+function describeAction(action: string) {
+  const mapping: Record<string, string> = {
+    'auth.signup': 'Регистрация',
+    'auth.login': 'Вход в систему',
+    'auth.refresh': 'Обновление сессии',
+    'auth.reset.request': 'Запрос сброса пароля',
+    'auth.reset.complete': 'Смена пароля',
+    'auth.verify-email': 'Подтверждение email',
+    'auth.session.revoke': 'Завершение сессии'
+  };
+
+  return mapping[action] ?? action;
+}
+
+function normalizeUserAgent(value?: string | null) {
+  if (!value) {
+    return 'Неизвестно';
+  }
+
+  if (value.length > 80) {
+    return `${value.slice(0, 77)}...`;
+  }
+
+  return value;
+}
+
+export default function ProfilePage() {
+  const { user, setAuthData, updateUser } = useAuth((state) => ({
+    user: state.user,
+    setAuthData: state.setAuthData,
+    updateUser: state.updateUser
+  }));
+  const [sessions, setSessions] = useState<AuthSessionDto[]>([]);
+  const [auditLogs, setAuditLogs] = useState<AuditLogEntryDto[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [revokeInProgress, setRevokeInProgress] = useState<string | null>(null);
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [passwordStatus, setPasswordStatus] = useState<string | null>(null);
+  const [verificationStatus, setVerificationStatus] = useState<string | null>(null);
+  const [verificationError, setVerificationError] = useState<string | null>(null);
+
+  const loadSecurity = useCallback(async () => {
+    if (!user) {
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await listSessions();
+      setSessions(data.sessions);
+      setAuditLogs(data.auditLogs);
+    } catch (err) {
+      console.error('Failed to load sessions', err);
+      setError('Не удалось загрузить информацию о безопасности. Попробуйте позже.');
+    } finally {
+      setLoading(false);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    void loadSecurity();
+  }, [loadSecurity]);
+
+  if (!user) {
+    return (
+      <>
+        <Head>
+          <title>Профиль — SuperMock</title>
+        </Head>
+        <main className="mx-auto flex min-h-screen max-w-4xl flex-col gap-6 px-4 py-10">
+          <h1 className="text-3xl font-semibold text-white">Профиль</h1>
+          <p className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-100">
+            Для доступа к настройкам безопасности необходимо войти в систему.
+          </p>
+        </main>
+      </>
+    );
+  }
+
+  const handleRevoke = async (sessionId: string) => {
+    setActionError(null);
+    setRevokeInProgress(sessionId);
+    try {
+      await revokeSession(sessionId);
+      await loadSecurity();
+    } catch (err) {
+      console.error('Failed to revoke session', err);
+      setActionError('Не удалось завершить сессию. Попробуйте ещё раз.');
+    } finally {
+      setRevokeInProgress(null);
+    }
+  };
+
+  const handlePasswordChange = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setPasswordStatus(null);
+    setActionError(null);
+
+    if (password.length < 8) {
+      setActionError('Пароль должен содержать не менее 8 символов.');
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setActionError('Пароли не совпадают.');
+      return;
+    }
+
+    try {
+      const updated = await changePassword(user.id, password);
+      updateUser({
+        id: updated.id,
+        email: updated.email,
+        role: updated.role,
+        emailVerified: Boolean(updated.emailVerifiedAt)
+      });
+      setPassword('');
+      setConfirmPassword('');
+      setPasswordStatus('Пароль успешно обновлён.');
+    } catch (err) {
+      console.error('Failed to change password', err);
+      setActionError('Не удалось обновить пароль. Попробуйте ещё раз.');
+    }
+  };
+
+  const handleRequestVerification = async () => {
+    setVerificationStatus(null);
+    setVerificationError(null);
+
+    const token = typeof window !== 'undefined' ? window.prompt('Введите токен из письма для подтверждения email:') : '';
+
+    if (!token) {
+      return;
+    }
+
+    try {
+      const response = await requestEmailVerification(token.trim());
+      setAuthData(response.tokens.accessToken, response.user);
+      setVerificationStatus('Email успешно подтверждён.');
+      await loadSecurity();
+    } catch (err) {
+      console.error('Failed to verify email', err);
+      setVerificationError('Не удалось подтвердить email. Проверьте токен и попробуйте снова.');
+    }
+  };
+
+  return (
+    <>
+      <Head>
+        <title>Профиль — SuperMock</title>
+      </Head>
+      <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-8 px-4 py-10">
+        <header>
+          <h1 className="text-3xl font-semibold text-white">Профиль</h1>
+          <p className="mt-2 text-sm text-slate-400">
+            Управляйте устройствами, сессиями и настройками безопасности аккаунта.
+          </p>
+        </header>
+
+        {error && (
+          <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-3 text-sm text-amber-100">
+            {error}
+          </div>
+        )}
+
+        <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40">
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 className="text-xl font-semibold text-white">Безопасность</h2>
+              <p className="text-sm text-slate-400">Активные устройства и последние действия.</p>
+            </div>
+            <div className="flex flex-col items-start gap-2 text-sm md:items-end">
+              <span
+                className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ${
+                  user.emailVerified ? 'bg-emerald-500/20 text-emerald-200' : 'bg-amber-500/20 text-amber-100'
+                }`}
+              >
+                <span className={`h-2 w-2 rounded-full ${user.emailVerified ? 'bg-emerald-400' : 'bg-amber-400'}`} />
+                {user.emailVerified ? 'Email подтверждён' : 'Email не подтверждён'}
+              </span>
+              {!user.emailVerified && (
+                <button
+                  type="button"
+                  onClick={handleRequestVerification}
+                  className="rounded-lg border border-secondary/40 px-3 py-1 text-xs font-semibold text-secondary transition hover:bg-secondary/10"
+                >
+                  Повторить верификацию
+                </button>
+              )}
+              {verificationStatus && <span className="text-xs text-emerald-300">{verificationStatus}</span>}
+              {verificationError && <span className="text-xs text-amber-200">{verificationError}</span>}
+            </div>
+          </div>
+
+          <div className="mt-6 space-y-4">
+            <div>
+              <h3 className="text-lg font-semibold text-white">Активные устройства</h3>
+              {loading ? (
+                <p className="mt-2 text-sm text-slate-400">Загрузка...</p>
+              ) : sessions.length === 0 ? (
+                <p className="mt-2 rounded-lg border border-slate-800 bg-slate-900/80 px-4 py-3 text-sm text-slate-400">
+                  Сессий не найдено. При входе с нового устройства оно появится здесь.
+                </p>
+              ) : (
+                <div className="mt-3 overflow-hidden rounded-xl border border-slate-800">
+                  <table className="min-w-full divide-y divide-slate-800 text-sm">
+                    <thead className="bg-slate-900/70 text-slate-400">
+                      <tr>
+                        <th className="px-4 py-3 text-left font-semibold">Создана</th>
+                        <th className="px-4 py-3 text-left font-semibold">IP</th>
+                        <th className="px-4 py-3 text-left font-semibold">Устройство</th>
+                        <th className="px-4 py-3 text-left font-semibold">Статус</th>
+                        <th className="px-4 py-3 text-right font-semibold">Действия</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-slate-800">
+                      {sessions.map((session) => (
+                        <tr key={session.id} className="text-slate-300">
+                          <td className="px-4 py-3">{formatDate(session.createdAt)}</td>
+                          <td className="px-4 py-3 text-xs md:text-sm">{session.ipAddress ?? '—'}</td>
+                          <td className="px-4 py-3 text-xs md:text-sm">{normalizeUserAgent(session.userAgent)}</td>
+                          <td className="px-4 py-3">
+                            {session.revokedAt ? (
+                              <span className="rounded-full bg-slate-800 px-2 py-1 text-xs text-slate-400">
+                                Завершена {formatDate(session.revokedAt)}
+                              </span>
+                            ) : (
+                              <span className="rounded-full bg-emerald-500/20 px-2 py-1 text-xs text-emerald-200">Активна</span>
+                            )}
+                          </td>
+                          <td className="px-4 py-3 text-right">
+                            <button
+                              type="button"
+                              disabled={Boolean(session.revokedAt) || revokeInProgress === session.id}
+                              onClick={() => handleRevoke(session.id)}
+                              className="inline-flex items-center rounded-lg border border-red-500/50 px-3 py-1 text-xs font-semibold text-red-200 transition hover:bg-red-500/10 disabled:cursor-not-allowed disabled:border-slate-800 disabled:text-slate-600"
+                            >
+                              {revokeInProgress === session.id ? 'Завершение...' : session.revokedAt ? 'Завершена' : 'Завершить'}
+                            </button>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+              {actionError && <p className="mt-3 text-sm text-amber-200">{actionError}</p>}
+            </div>
+
+            <div>
+              <h3 className="text-lg font-semibold text-white">Последние действия</h3>
+              {loading ? (
+                <p className="mt-2 text-sm text-slate-400">Загрузка...</p>
+              ) : auditLogs.length === 0 ? (
+                <p className="mt-2 rounded-lg border border-slate-800 bg-slate-900/80 px-4 py-3 text-sm text-slate-400">
+                  История действий пока пуста.
+                </p>
+              ) : (
+                <ul className="mt-3 space-y-2 text-sm text-slate-300">
+                  {auditLogs.map((entry) => (
+                    <li
+                      key={entry.id}
+                      className="flex flex-col gap-1 rounded-lg border border-slate-800 bg-slate-900/70 px-4 py-3 md:flex-row md:items-center md:justify-between"
+                    >
+                      <div>
+                        <p className="font-semibold text-white">{describeAction(entry.action)}</p>
+                        <p className="text-xs text-slate-400">
+                          IP: {entry.ipAddress ?? '—'} · Устройство: {normalizeUserAgent(entry.userAgent)}
+                        </p>
+                      </div>
+                      <span className="text-xs text-slate-400">{formatDate(entry.createdAt)}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-950/40">
+          <h2 className="text-xl font-semibold text-white">Смена пароля</h2>
+          <p className="mt-1 text-sm text-slate-400">Используйте сильный пароль, чтобы защитить аккаунт.</p>
+
+          <form className="mt-4 space-y-4" onSubmit={handlePasswordChange}>
+            <div className="grid gap-2">
+              <label className="text-sm font-semibold text-slate-300" htmlFor="new-password">
+                Новый пароль
+              </label>
+              <input
+                id="new-password"
+                type="password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                className="w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-white focus:border-secondary focus:outline-none"
+                placeholder="Минимум 8 символов"
+                minLength={8}
+                required
+              />
+            </div>
+
+            <div className="grid gap-2">
+              <label className="text-sm font-semibold text-slate-300" htmlFor="confirm-password">
+                Подтверждение пароля
+              </label>
+              <input
+                id="confirm-password"
+                type="password"
+                value={confirmPassword}
+                onChange={(event) => setConfirmPassword(event.target.value)}
+                className="w-full rounded-lg border border-slate-800 bg-slate-950 px-3 py-2 text-sm text-white focus:border-secondary focus:outline-none"
+                placeholder="Повторите пароль"
+                minLength={8}
+                required
+              />
+            </div>
+
+            <button
+              type="submit"
+              className="rounded-lg bg-secondary px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-secondary/90"
+            >
+              Обновить пароль
+            </button>
+
+            {passwordStatus && <p className="text-sm text-emerald-300">{passwordStatus}</p>}
+            {actionError && <p className="text-sm text-amber-200">{actionError}</p>}
+          </form>
+        </section>
+      </main>
+    </>
+  );
+}

--- a/app/src/store/useAuth.ts
+++ b/app/src/store/useAuth.ts
@@ -13,6 +13,7 @@ interface AuthState {
   login: (email: string, password: string) => Promise<void>;
   logout: () => void;
   setAuthData: (accessToken: string, user: AuthState['user']) => void;
+  updateUser: (user: AuthState['user']) => void;
 }
 
 export const useAuth = create<AuthState>()(
@@ -57,13 +58,20 @@ export const useAuth = create<AuthState>()(
           isAuthenticated: false,
         });
       },
-      
+
       setAuthData: (accessToken: string, user: AuthState['user']) => {
         set({
           accessToken,
           user,
           isAuthenticated: true,
         });
+      },
+
+      updateUser: (user: AuthState['user']) => {
+        set((state) => ({
+          user,
+          isAuthenticated: user ? true : state.isAuthenticated && Boolean(state.accessToken),
+        }));
       },
     }),
     {

--- a/server/src/modules/account.ts
+++ b/server/src/modules/account.ts
@@ -1,0 +1,109 @@
+import type { Prisma } from '@prisma/client';
+
+import type {
+  AccountSecurityOverviewDto,
+  AuditLogEntryDto,
+  AuthSessionDto
+} from '../../../shared/src/types/auth.js';
+import { prisma } from './prisma.js';
+
+type RefreshTokenRecord = Prisma.RefreshTokenGetPayload<{}>;
+type AuditLogRecord = Prisma.AuditLogGetPayload<{}>;
+
+type SessionMetadata = {
+  ipAddress?: string;
+  userAgent?: string;
+  actorUserId?: string;
+};
+
+function mapSession(record: RefreshTokenRecord): AuthSessionDto {
+  return {
+    id: record.id,
+    createdAt: record.createdAt.toISOString(),
+    ipAddress: record.createdByIp ?? undefined,
+    userAgent: record.userAgent ?? undefined,
+    revokedAt: record.revokedAt ? record.revokedAt.toISOString() : null
+  };
+}
+
+function mapAuditLog(record: AuditLogRecord): AuditLogEntryDto {
+  return {
+    id: record.id,
+    action: record.action,
+    createdAt: record.createdAt.toISOString(),
+    ipAddress: record.ipAddress ?? undefined,
+    userAgent: record.userAgent ?? undefined
+  };
+}
+
+export async function listAccountSecurity(
+  userId: string,
+  options?: { sessionLimit?: number; auditLimit?: number }
+): Promise<AccountSecurityOverviewDto> {
+  const sessionLimit = options?.sessionLimit ?? 20;
+  const auditLimit = options?.auditLimit ?? 20;
+
+  const [sessions, auditLogs] = await prisma.$transaction([
+    prisma.refreshToken.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+      take: sessionLimit
+    }),
+    prisma.auditLog.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+      take: auditLimit
+    })
+  ]);
+
+  return {
+    sessions: sessions.map(mapSession),
+    auditLogs: auditLogs.map(mapAuditLog)
+  };
+}
+
+export async function findSessionById(id: string) {
+  return prisma.refreshToken.findUnique({ where: { id } });
+}
+
+export async function revokeSessionById(
+  sessionId: string,
+  metadata: SessionMetadata
+): Promise<AuthSessionDto> {
+  const existing = await prisma.refreshToken.findUnique({ where: { id: sessionId } });
+
+  if (!existing) {
+    throw new Error('Session not found');
+  }
+
+  if (!existing.revokedAt) {
+    await prisma.refreshToken.update({
+      where: { id: sessionId },
+      data: {
+        revokedAt: new Date(),
+        revokedByIp: metadata.ipAddress ?? existing.revokedByIp ?? null
+      }
+    });
+
+    await prisma.auditLog.create({
+      data: {
+        userId: existing.userId,
+        action: 'auth.session.revoke',
+        ipAddress: metadata.ipAddress,
+        userAgent: metadata.userAgent,
+        metadata:
+          metadata.actorUserId && metadata.actorUserId !== existing.userId
+            ? ({ actorUserId: metadata.actorUserId } as Prisma.InputJsonValue)
+            : undefined
+      }
+    });
+  }
+
+  const refreshed = await prisma.refreshToken.findUnique({ where: { id: sessionId } });
+
+  if (!refreshed) {
+    throw new Error('Session not found');
+  }
+
+  return mapSession(refreshed);
+}

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,6 +1,7 @@
 export * from './types/user.js';
 export * from './types/matching.js';
 export * from './types/payments.js';
+export * from './types/auth.js';
 export * from './constants/interview.js';
 export * from './constants/payments.js';
 export * from './utils/scoring.js';

--- a/shared/src/types/auth.ts
+++ b/shared/src/types/auth.ts
@@ -1,0 +1,29 @@
+import type { UserRole } from './user.js';
+
+export type AuthUserDto = {
+  id: string;
+  email: string;
+  role: UserRole;
+  emailVerified: boolean;
+};
+
+export type AuthSessionDto = {
+  id: string;
+  createdAt: string;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+  revokedAt?: string | null;
+};
+
+export type AuditLogEntryDto = {
+  id: string;
+  action: string;
+  createdAt: string;
+  ipAddress?: string | null;
+  userAgent?: string | null;
+};
+
+export type AccountSecurityOverviewDto = {
+  sessions: AuthSessionDto[];
+  auditLogs: AuditLogEntryDto[];
+};


### PR DESCRIPTION
## Summary
- add shared auth DTOs and a server account module to list and revoke user sessions with audit logging
- expose `/auth/sessions` and client wrappers for listing, revoking sessions, requesting email verification, and changing password
- add a profile security page with session table, audit log feed, email verification indicator, and password change form updating Zustand auth state

## Testing
- pnpm --filter ./app lint
- pnpm --filter ./server type-check *(fails: repository already has numerous TypeScript errors in matching modules and tests)*
- pnpm lint *(fails: server and shared packages lack ESLint configuration files)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe122da648327abf2be8d816cd9c7