### PR TITLE
feat: add profile notifications dashboard

### DIFF
--- a/app/src/components/profile/NotificationToggle.tsx
+++ b/app/src/components/profile/NotificationToggle.tsx
@@ -1,0 +1,179 @@
+import { useMemo, useState } from 'react';
+
+import { markNotificationsRead } from '@/lib/api';
+
+export interface NotificationToggleProps {
+  channel: string;
+  label: string;
+  description: string;
+  enabled: boolean;
+  unreadCount?: number;
+  notificationIds?: string[];
+  onToggle?: (nextValue: boolean) => Promise<void> | void;
+  onMarkRead?: (notificationIds: string[]) => Promise<void> | void;
+  onMarked?: (notificationIds: string[]) => void;
+  isSaving?: boolean;
+  isMarking?: boolean;
+  disabled?: boolean;
+  showMarkReadButton?: boolean;
+}
+
+function formatChannelName(channel: string) {
+  const normalized = channel.toLowerCase();
+
+  switch (normalized) {
+    case 'telegram':
+      return 'Telegram';
+    case 'email':
+      return 'Email';
+    case 'push':
+      return 'Push';
+    case 'in-app':
+      return 'В приложении';
+    default:
+      return channel;
+  }
+}
+
+export function NotificationToggle({
+  channel,
+  label,
+  description,
+  enabled,
+  unreadCount = 0,
+  notificationIds = [],
+  onToggle,
+  onMarkRead,
+  onMarked,
+  isSaving = false,
+  isMarking = false,
+  disabled = false,
+  showMarkReadButton = true
+}: NotificationToggleProps) {
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [isMarkingLocal, setIsMarkingLocal] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const hasUnread = unreadCount > 0;
+  const isToggleDisabled = disabled || isSaving || isUpdating;
+  const isMarkButtonDisabled =
+    disabled || isMarking || isMarkingLocal || notificationIds.length === 0;
+
+  const statusText = useMemo(() => {
+    const parts: string[] = [];
+
+    parts.push(enabled ? 'Включено' : 'Выключено');
+
+    if (unreadCount > 0) {
+      parts.push(`непрочитанных: ${unreadCount}`);
+    } else {
+      parts.push('непрочитанных нет');
+    }
+
+    return parts.join(' · ');
+  }, [enabled, unreadCount]);
+
+  const handleToggle = async () => {
+    if (!onToggle) {
+      return;
+    }
+
+    setError(null);
+    setIsUpdating(true);
+
+    try {
+      await onToggle(!enabled);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Не удалось обновить настройки уведомлений';
+      setError(message);
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  const handleMarkRead = async () => {
+    if (notificationIds.length === 0) {
+      return;
+    }
+
+    setError(null);
+    setIsMarkingLocal(true);
+
+    try {
+      if (onMarkRead) {
+        await onMarkRead(notificationIds);
+      } else {
+        await markNotificationsRead({ notificationIds });
+      }
+
+      onMarked?.(notificationIds);
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Не удалось отметить уведомления прочитанными';
+      setError(message);
+    } finally {
+      setIsMarkingLocal(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3 rounded-2xl border border-slate-800 bg-slate-950/70 p-4 shadow-sm shadow-slate-950/60">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <p className="text-sm font-semibold text-white">{label}</p>
+          <p className="text-xs text-slate-400">{description}</p>
+          <p className="mt-2 text-[11px] uppercase tracking-wide text-slate-500">
+            {formatChannelName(channel)} · {statusText}
+          </p>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={enabled}
+          onClick={handleToggle}
+          disabled={isToggleDisabled}
+          className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary/60 ${
+            enabled ? 'bg-secondary/80' : 'bg-slate-700'
+          } ${isToggleDisabled ? 'opacity-60' : ''}`}
+        >
+          <span
+            className={`inline-block h-5 w-5 transform rounded-full bg-slate-950 transition ${
+              enabled ? 'translate-x-5' : 'translate-x-1'
+            }`}
+          />
+        </button>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3 text-xs text-slate-300">
+        {hasUnread ? (
+          <span className="rounded-full border border-amber-400/60 px-2 py-1 text-amber-200">
+            Есть непрочитанные
+          </span>
+        ) : (
+          <span className="rounded-full border border-slate-700 px-2 py-1 text-slate-400">
+            Всё прочитано
+          </span>
+        )}
+        {showMarkReadButton && (
+          <button
+            type="button"
+            onClick={handleMarkRead}
+            disabled={isMarkButtonDisabled}
+            className="rounded-full border border-slate-700 px-3 py-1 text-xs font-semibold text-slate-200 transition hover:border-secondary/60 hover:text-secondary disabled:cursor-not-allowed disabled:border-slate-800 disabled:text-slate-500"
+          >
+            {isMarkingLocal || isMarking ? 'Отмечаем…' : 'Прочитано'}
+          </button>
+        )}
+      </div>
+
+      {error && (
+        <p className="text-xs text-rose-300">{error}</p>
+      )}
+    </div>
+  );
+}
+
+export default NotificationToggle;

--- a/app/src/hooks/useNotifications.ts
+++ b/app/src/hooks/useNotifications.ts
@@ -1,0 +1,465 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import {
+  fetchNotifications,
+  formatNotification,
+  markNotificationsRead,
+  subscribeToNotifications,
+  type FormattedNotification,
+  type NotificationSubscription
+} from '@/lib/api';
+import type { NotificationDto } from '../../../shared/src/types/realtime.js';
+
+export type NotificationConnectionStatus = 'idle' | 'connecting' | 'open' | 'closed' | 'error';
+
+export type NotificationFilters = {
+  unreadOnly: boolean;
+  importantOnly: boolean;
+};
+
+export type NotificationGroup = {
+  date: string;
+  items: FormattedNotification[];
+};
+
+type ChannelStats = Record<string, { total: number; unread: number }>;
+
+type UseNotificationsOptions = {
+  initialLimit?: number;
+  filters?: Partial<NotificationFilters>;
+};
+
+const DEFAULT_LIMIT = 20;
+
+function mergeNotifications(
+  current: FormattedNotification[],
+  incoming: FormattedNotification[]
+) {
+  if (incoming.length === 0) {
+    return current;
+  }
+
+  const map = new Map(current.map((item) => [item.id, item] as const));
+
+  for (const item of incoming) {
+    map.set(item.id, item);
+  }
+
+  return Array.from(map.values()).sort(
+    (a, b) => b.createdAt.getTime() - a.createdAt.getTime()
+  );
+}
+
+export function useNotifications(options: UseNotificationsOptions = {}) {
+  const limitRef = useRef(options.initialLimit ?? DEFAULT_LIMIT);
+  const isMountedRef = useRef(false);
+  const subscriptionRef = useRef<NotificationSubscription | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [notifications, setNotifications] = useState<FormattedNotification[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [isFetchingMore, setIsFetchingMore] = useState(false);
+  const [isMarking, setIsMarking] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
+  const [wsError, setWsError] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [connectionStatus, setConnectionStatus] = useState<NotificationConnectionStatus>('idle');
+  const [lastSyncedAt, setLastSyncedAt] = useState<Date | null>(null);
+  const [filters, setFilters] = useState<NotificationFilters>({
+    unreadOnly: options.filters?.unreadOnly ?? false,
+    importantOnly: options.filters?.importantOnly ?? false
+  });
+
+  const clearReconnectTimer = useCallback(() => {
+    if (reconnectTimerRef.current) {
+      clearTimeout(reconnectTimerRef.current);
+      reconnectTimerRef.current = null;
+    }
+  }, []);
+
+  const loadInitial = useCallback(async () => {
+    setIsLoading(true);
+    setLoadError(null);
+
+    try {
+      const data = await fetchNotifications({ limit: limitRef.current });
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      setNotifications(data.map((item) => formatNotification(item)));
+      setHasMore(data.length === limitRef.current);
+      setLastSyncedAt(new Date());
+    } catch (error) {
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      const message =
+        error instanceof Error ? error.message : 'Не удалось загрузить уведомления';
+      setLoadError(message);
+      setWsError(message);
+    } finally {
+      if (isMountedRef.current) {
+        setIsLoading(false);
+      }
+    }
+  }, []);
+
+  const refreshLatest = useCallback(async () => {
+    setIsRefreshing(true);
+
+    try {
+      const data = await fetchNotifications({ limit: limitRef.current });
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      setNotifications((current) =>
+        mergeNotifications(
+          current,
+          data.map((item) => formatNotification(item))
+        )
+      );
+      setHasMore(data.length === limitRef.current);
+      setLastSyncedAt(new Date());
+    } catch (error) {
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      const message =
+        error instanceof Error ? error.message : 'Не удалось обновить список уведомлений';
+      setWsError(message);
+    } finally {
+      if (isMountedRef.current) {
+        setIsRefreshing(false);
+      }
+    }
+  }, []);
+
+  const handleRealtimeNotification = useCallback(
+    (notification: NotificationDto) => {
+      setNotifications((current) => {
+        const formatted = formatNotification(notification);
+        const exists = current.find((item) => item.id === formatted.id);
+
+        if (!exists) {
+          return [formatted, ...current].sort(
+            (a, b) => b.createdAt.getTime() - a.createdAt.getTime()
+          );
+        }
+
+        return current.map((item) =>
+          item.id === formatted.id ? { ...item, ...formatted } : item
+        );
+      });
+    },
+    []
+  );
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    void loadInitial();
+
+    return () => {
+      isMountedRef.current = false;
+      clearReconnectTimer();
+      subscriptionRef.current?.close();
+    };
+  }, [clearReconnectTimer, loadInitial]);
+
+  useEffect(() => {
+    if (!isMountedRef.current) {
+      return;
+    }
+
+    clearReconnectTimer();
+    subscriptionRef.current?.close();
+
+    setConnectionStatus('connecting');
+    setWsError(null);
+
+    const subscription = subscribeToNotifications({
+      onNotification: handleRealtimeNotification,
+      onOpen: () => {
+        setConnectionStatus('open');
+        setWsError(null);
+      },
+      onClose: () => {
+        setConnectionStatus('closed');
+        setWsError('Соединение с уведомлениями закрыто');
+        clearReconnectTimer();
+        reconnectTimerRef.current = setTimeout(() => {
+          if (!isMountedRef.current) {
+            return;
+          }
+
+          subscriptionRef.current?.reconnect();
+        }, 5000);
+        void refreshLatest();
+      },
+      onError: (error) => {
+        setConnectionStatus('error');
+        const message = error.message || 'Ошибка подключения к уведомлениям';
+        setWsError(message);
+        clearReconnectTimer();
+        reconnectTimerRef.current = setTimeout(() => {
+          if (!isMountedRef.current) {
+            return;
+          }
+
+          subscriptionRef.current?.reconnect();
+        }, 5000);
+        void refreshLatest();
+      }
+    });
+
+    subscriptionRef.current = subscription;
+
+    return () => {
+      subscription.close();
+    };
+  }, [clearReconnectTimer, handleRealtimeNotification, refreshLatest]);
+
+  const loadMore = useCallback(async () => {
+    if (isFetchingMore || notifications.length === 0) {
+      return;
+    }
+
+    setIsFetchingMore(true);
+
+    try {
+      const lastNotification = notifications[notifications.length - 1];
+      const cursor = lastNotification?.raw.createdAt ?? lastNotification?.createdAtIso;
+      const data = await fetchNotifications({
+        limit: limitRef.current,
+        before: cursor
+      });
+
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      if (data.length === 0) {
+        setHasMore(false);
+        return;
+      }
+
+      setNotifications((current) =>
+        mergeNotifications(
+          current,
+          data.map((item) => formatNotification(item))
+        )
+      );
+      setHasMore(data.length === limitRef.current);
+    } catch (error) {
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      const message =
+        error instanceof Error ? error.message : 'Не удалось загрузить историю уведомлений';
+      setWsError(message);
+    } finally {
+      if (isMountedRef.current) {
+        setIsFetchingMore(false);
+      }
+    }
+  }, [isFetchingMore, notifications]);
+
+  const markAsRead = useCallback(
+    async (notificationIds: string[]) => {
+      if (notificationIds.length === 0) {
+        return 0;
+      }
+
+      setIsMarking(true);
+
+      try {
+        const { updated } = await markNotificationsRead({ notificationIds });
+
+        if (!isMountedRef.current) {
+          return updated;
+        }
+
+        setNotifications((current) =>
+          current.map((item) =>
+            notificationIds.includes(item.id)
+              ? { ...item, isRead: true, readAt: new Date() }
+              : item
+          )
+        );
+
+        return updated;
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Не удалось обновить статус уведомлений';
+        setWsError(message);
+        throw error;
+      } finally {
+        if (isMountedRef.current) {
+          setIsMarking(false);
+        }
+      }
+    },
+    []
+  );
+
+  const markAllAsRead = useCallback(async () => {
+    if (notifications.length === 0) {
+      return 0;
+    }
+
+    setIsMarking(true);
+
+    try {
+      const before = new Date().toISOString();
+      const { updated } = await markNotificationsRead({ before });
+
+      if (!isMountedRef.current) {
+        return updated;
+      }
+
+      const markedAt = new Date();
+      setNotifications((current) =>
+        current.map((item) =>
+          item.createdAt <= markedAt
+            ? { ...item, isRead: true, readAt: markedAt }
+            : item
+        )
+      );
+
+      return updated;
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Не удалось отметить уведомления прочитанными';
+      setWsError(message);
+      throw error;
+    } finally {
+      if (isMountedRef.current) {
+        setIsMarking(false);
+      }
+    }
+  }, [notifications.length]);
+
+  const filteredNotifications = useMemo(() => {
+    return notifications.filter((notification) => {
+      if (filters.unreadOnly && notification.isRead) {
+        return false;
+      }
+
+      if (filters.importantOnly && notification.importance !== 'high') {
+        return false;
+      }
+
+      return true;
+    });
+  }, [notifications, filters]);
+
+  const groupedNotifications = useMemo<NotificationGroup[]>(() => {
+    const buckets = new Map<string, FormattedNotification[]>();
+
+    for (const notification of filteredNotifications) {
+      const list = buckets.get(notification.dateKey) ?? [];
+      list.push(notification);
+      buckets.set(notification.dateKey, list);
+    }
+
+    const groups = Array.from(buckets.entries()).map(([date, items]) => ({
+      date,
+      items: items.sort(
+        (a, b) => b.createdAt.getTime() - a.createdAt.getTime()
+      )
+    }));
+
+    return groups.sort((a, b) => {
+      const aTime = a.items[0]?.createdAt.getTime() ?? 0;
+      const bTime = b.items[0]?.createdAt.getTime() ?? 0;
+      return bTime - aTime;
+    });
+  }, [filteredNotifications]);
+
+  const channelStats = useMemo<ChannelStats>(() => {
+    const stats: ChannelStats = {};
+
+    for (const notification of notifications) {
+      const key = notification.channel ?? 'in-app';
+      if (!stats[key]) {
+        stats[key] = { total: 0, unread: 0 };
+      }
+
+      stats[key].total += 1;
+      if (!notification.isRead) {
+        stats[key].unread += 1;
+      }
+    }
+
+    return stats;
+  }, [notifications]);
+
+  const sourceStats = useMemo<ChannelStats>(() => {
+    const stats: ChannelStats = {};
+
+    for (const notification of notifications) {
+      const key = notification.source ?? 'system';
+      if (!stats[key]) {
+        stats[key] = { total: 0, unread: 0 };
+      }
+
+      stats[key].total += 1;
+      if (!notification.isRead) {
+        stats[key].unread += 1;
+      }
+    }
+
+    return stats;
+  }, [notifications]);
+
+  const unreadCount = useMemo(
+    () => notifications.filter((notification) => !notification.isRead).length,
+    [notifications]
+  );
+
+  const importantCount = useMemo(
+    () =>
+      notifications.filter(
+        (notification) => notification.importance === 'high' && !notification.isRead
+      ).length,
+    [notifications]
+  );
+
+  const reconnect = useCallback(() => {
+    setWsError(null);
+    setConnectionStatus('connecting');
+    clearReconnectTimer();
+    subscriptionRef.current?.reconnect();
+  }, [clearReconnectTimer]);
+
+  return {
+    notifications,
+    filteredNotifications,
+    groupedNotifications,
+    filters,
+    setFilters,
+    isLoading,
+    isRefreshing,
+    isFetchingMore,
+    isMarking,
+    hasMore,
+    unreadCount,
+    importantCount,
+    channelStats,
+    sourceStats,
+    connectionStatus,
+    wsError,
+    loadError,
+    lastSyncedAt,
+    loadMore,
+    refresh: refreshLatest,
+    markAsRead,
+    markAllAsRead,
+    reconnect
+  };
+}
+

--- a/app/src/pages/profile.tsx
+++ b/app/src/pages/profile.tsx
@@ -1,0 +1,453 @@
+import Head from 'next/head';
+import { useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  BoltIcon,
+  CheckIcon,
+  ExclamationTriangleIcon,
+  SignalIcon
+} from '@heroicons/react/24/outline';
+
+import NotificationToggle from '@/components/profile/NotificationToggle';
+import { useNotifications } from '@/hooks/useNotifications';
+import { fetchUser, type UpdateUserPayload, updateUser } from '@/lib/api';
+import { useAuth } from '@/store/useAuth';
+
+const DEFAULT_CHANNELS: Record<string, boolean> = {
+  telegram: false,
+  email: false,
+  push: false
+};
+
+type NotificationSettingsShape = {
+  channels: Record<string, boolean>;
+  updatedAt?: string;
+};
+
+function parseNotificationSettings(
+  profile: Record<string, unknown> | null | undefined
+): NotificationSettingsShape {
+  const settings = ((profile as { notificationSettings?: Record<string, unknown> } | null)?.notificationSettings ?? {}) as Record<string, unknown>;
+  const channels = (settings.channels as Record<string, boolean> | undefined) ?? {};
+
+  return {
+    channels: { ...DEFAULT_CHANNELS, ...channels },
+    updatedAt: typeof settings.updatedAt === 'string' ? settings.updatedAt : undefined
+  };
+}
+
+function formatDateTime(value?: string) {
+  if (!value) {
+    return null;
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return new Intl.DateTimeFormat('ru-RU', {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  }).format(date);
+}
+
+export default function ProfilePage() {
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const [channelError, setChannelError] = useState<string | null>(null);
+
+  const {
+    notifications,
+    filteredNotifications,
+    groupedNotifications,
+    filters,
+    setFilters,
+    isLoading: isNotificationsLoading,
+    isRefreshing,
+    isFetchingMore,
+    isMarking,
+    hasMore,
+    unreadCount,
+    importantCount,
+    channelStats,
+    connectionStatus,
+    wsError,
+    loadError,
+    lastSyncedAt,
+    loadMore,
+    refresh,
+    markAsRead,
+    markAllAsRead,
+    reconnect
+  } = useNotifications({ initialLimit: 30 });
+
+  const profileQuery = useQuery({
+    queryKey: ['profile', user?.id],
+    queryFn: () => fetchUser(user!.id),
+    enabled: Boolean(user?.id)
+  });
+
+  const notificationSettings = useMemo(
+    () => parseNotificationSettings(profileQuery.data?.profile as Record<string, unknown> | null | undefined),
+    [profileQuery.data?.profile]
+  );
+
+  const updateChannelsMutation = useMutation({
+    mutationFn: async (nextChannels: Record<string, boolean>) => {
+      if (!user?.id) {
+        throw new Error('Необходимо войти в аккаунт');
+      }
+
+      const currentProfile = ((profileQuery.data?.profile ?? {}) as Record<string, unknown>) ?? {};
+      const currentSettings = ((currentProfile.notificationSettings as Record<string, unknown> | undefined) ?? {}) as Record<string, unknown>;
+
+      const payload: UpdateUserPayload = {
+        profile: {
+          ...currentProfile,
+          notificationSettings: {
+            ...currentSettings,
+            channels: nextChannels,
+            updatedAt: new Date().toISOString()
+          }
+        }
+      };
+
+      return updateUser(user.id, payload);
+    },
+    onSuccess: (data) => {
+      if (!user?.id) {
+        return;
+      }
+
+      queryClient.setQueryData(['profile', user.id], data);
+      setChannelError(null);
+    },
+    onError: (error: unknown) => {
+      const message = error instanceof Error ? error.message : 'Не удалось сохранить настройки каналов';
+      setChannelError(message);
+    }
+  });
+
+  const handleChannelToggle = async (channel: string, nextValue: boolean) => {
+    const nextChannels = { ...notificationSettings.channels, [channel]: nextValue };
+    await updateChannelsMutation.mutateAsync(nextChannels);
+  };
+
+  const channelNotificationIds = useMemo(() => {
+    const result: Record<string, string[]> = {};
+
+    for (const notification of notifications) {
+      const key = notification.channel ?? 'in-app';
+      if (!result[key]) {
+        result[key] = [];
+      }
+
+      if (!notification.isRead) {
+        result[key].push(notification.id);
+      }
+    }
+
+    return result;
+  }, [notifications]);
+
+  const filteredUnreadIds = useMemo(
+    () => filteredNotifications.filter((item) => !item.isRead).map((item) => item.id),
+    [filteredNotifications]
+  );
+
+  const lastSyncedLabel = lastSyncedAt
+    ? new Intl.DateTimeFormat('ru-RU', { dateStyle: 'short', timeStyle: 'short' }).format(lastSyncedAt)
+    : null;
+
+  const connectionColor = {
+    open: 'text-emerald-400',
+    connecting: 'text-amber-300',
+    closed: 'text-slate-400',
+    error: 'text-rose-400',
+    idle: 'text-slate-400'
+  }[connectionStatus];
+
+  return (
+    <>
+      <Head>
+        <title>Профиль — уведомления | SuperMock</title>
+      </Head>
+
+      <main className="min-h-screen bg-gradient-to-b from-slate-950 via-slate-950 to-slate-900 pb-16 text-white">
+        <div className="mx-auto w-full max-w-6xl px-6 pt-16">
+          <header className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Профиль</p>
+              <h1 className="mt-2 text-3xl font-semibold">Центр уведомлений</h1>
+              <p className="mt-2 max-w-2xl text-sm text-slate-400">
+                Управляйте каналами связи и оперативно просматривайте ключевые события: новые матчи,
+                обновления расписания и системные сообщения. Отмечайте уведомления как прочитанные в один клик и не
+                упускайте важное.
+              </p>
+            </div>
+            <div className="flex flex-col items-end gap-2 text-xs text-slate-400">
+              <div className={`flex items-center gap-2 ${connectionColor}`}>
+                <SignalIcon className="h-4 w-4" />
+                <span className="font-semibold uppercase tracking-wide">{connectionStatus}</span>
+              </div>
+              {lastSyncedLabel && <span>Обновлено: {lastSyncedLabel}</span>}
+              {isRefreshing && <span>Синхронизация…</span>}
+            </div>
+          </header>
+
+          {wsError && (
+            <div className="mt-6 flex flex-wrap items-center justify-between gap-4 rounded-xl border border-amber-500/50 bg-amber-500/10 px-4 py-3 text-sm text-amber-200">
+              <div className="flex items-center gap-2">
+                <ExclamationTriangleIcon className="h-5 w-5" />
+                <span>{wsError}</span>
+              </div>
+              <button
+                type="button"
+                onClick={reconnect}
+                className="rounded-full border border-amber-400/70 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-100 transition hover:border-amber-200 hover:text-amber-50"
+              >
+                Переподключить
+              </button>
+            </div>
+          )}
+
+          {loadError && (
+            <div className="mt-6 rounded-xl border border-rose-500/50 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+              {loadError}
+            </div>
+          )}
+
+          <section className="mt-10 grid gap-6 lg:grid-cols-[380px_1fr]">
+            <aside className="flex flex-col gap-6">
+              <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-sm shadow-slate-950/50">
+                <h2 className="text-lg font-semibold">Каналы уведомлений</h2>
+                <p className="mt-2 text-sm text-slate-400">
+                  Выберите, где хотите получать обновления. Отключение канала не влияет на историю уведомлений.
+                </p>
+                <div className="mt-6 space-y-3">
+                  <NotificationToggle
+                    channel="telegram"
+                    label="Telegram"
+                    description="Моментальные сообщения от бота SuperMock"
+                    enabled={notificationSettings.channels.telegram}
+                    unreadCount={channelStats.telegram?.unread ?? 0}
+                    notificationIds={channelNotificationIds.telegram ?? []}
+                    onToggle={(next) => handleChannelToggle('telegram', next)}
+                    onMarkRead={async (ids) => {
+                      await markAsRead(ids);
+                    }}
+                    isSaving={updateChannelsMutation.isPending}
+                    isMarking={isMarking}
+                  />
+                  <NotificationToggle
+                    channel="email"
+                    label="Email"
+                    description="Ежедневная сводка и результаты матчей"
+                    enabled={notificationSettings.channels.email}
+                    unreadCount={channelStats.email?.unread ?? 0}
+                    notificationIds={channelNotificationIds.email ?? []}
+                    onToggle={(next) => handleChannelToggle('email', next)}
+                    onMarkRead={async (ids) => {
+                      await markAsRead(ids);
+                    }}
+                    isSaving={updateChannelsMutation.isPending}
+                    isMarking={isMarking}
+                  />
+                  <NotificationToggle
+                    channel="push"
+                    label="Push"
+                    description="Браузерные уведомления о назначениях и изменениях"
+                    enabled={notificationSettings.channels.push}
+                    unreadCount={channelStats.push?.unread ?? 0}
+                    notificationIds={channelNotificationIds.push ?? []}
+                    onToggle={(next) => handleChannelToggle('push', next)}
+                    onMarkRead={async (ids) => {
+                      await markAsRead(ids);
+                    }}
+                    isSaving={updateChannelsMutation.isPending}
+                    isMarking={isMarking}
+                  />
+                </div>
+                {channelError && (
+                  <p className="mt-3 text-xs text-rose-300">{channelError}</p>
+                )}
+                {notificationSettings.updatedAt && (
+                  <p className="mt-3 text-xs text-slate-500">
+                    Обновлено: {formatDateTime(notificationSettings.updatedAt)}
+                  </p>
+                )}
+              </div>
+
+              <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-5 text-sm text-slate-300 shadow-sm shadow-slate-950/40">
+                <h3 className="flex items-center gap-2 text-base font-semibold text-white">
+                  <BoltIcon className="h-5 w-5 text-secondary" />
+                  Краткая статистика
+                </h3>
+                <ul className="mt-3 space-y-2 text-xs text-slate-400">
+                  <li>Всего уведомлений: {notifications.length}</li>
+                  <li>Непрочитанные: {unreadCount}</li>
+                  <li>Важные непрочитанные: {importantCount}</li>
+                </ul>
+              </div>
+            </aside>
+
+            <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-sm shadow-slate-950/50">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <h2 className="text-lg font-semibold">Лента уведомлений</h2>
+                  <p className="text-sm text-slate-400">
+                    Просматривайте историю событий, фильтруйте по важности и отмечайте уведомления прочитанными.
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-2 text-xs">
+                  <button
+                    type="button"
+                    onClick={() => setFilters((previous) => ({
+                      ...previous,
+                      unreadOnly: !previous.unreadOnly
+                    }))}
+                    className={`rounded-full border px-3 py-1 font-semibold transition ${
+                      filters.unreadOnly
+                        ? 'border-secondary/70 bg-secondary/10 text-secondary'
+                        : 'border-slate-700 text-slate-300 hover:border-secondary/40 hover:text-secondary'
+                    }`}
+                  >
+                    Только непрочитанные ({unreadCount})
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setFilters((previous) => ({
+                      ...previous,
+                      importantOnly: !previous.importantOnly
+                    }))}
+                    className={`rounded-full border px-3 py-1 font-semibold transition ${
+                      filters.importantOnly
+                        ? 'border-amber-400/80 bg-amber-400/10 text-amber-200'
+                        : 'border-slate-700 text-slate-300 hover:border-amber-300/60 hover:text-amber-200'
+                    }`}
+                  >
+                    Важные ({importantCount})
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => refresh()}
+                    className="rounded-full border border-slate-700 px-3 py-1 font-semibold text-slate-300 transition hover:border-secondary/40 hover:text-secondary"
+                  >
+                    Обновить
+                  </button>
+                </div>
+              </div>
+
+              <div className="mt-4 flex flex-wrap gap-3 text-xs">
+                <button
+                  type="button"
+                  onClick={() => markAsRead(filteredUnreadIds)}
+                  disabled={filteredUnreadIds.length === 0 || isMarking}
+                  className="rounded-lg bg-secondary px-4 py-2 font-semibold text-slate-950 transition disabled:cursor-not-allowed disabled:bg-secondary/40"
+                >
+                  Прочитано
+                </button>
+                <button
+                  type="button"
+                  onClick={() => markAllAsRead()}
+                  disabled={notifications.length === 0 || isMarking}
+                  className="rounded-lg border border-slate-700 px-4 py-2 font-semibold text-slate-200 transition hover:border-secondary/50 hover:text-secondary disabled:cursor-not-allowed disabled:border-slate-800 disabled:text-slate-600"
+                >
+                  Отметить всё
+                </button>
+              </div>
+
+              {isNotificationsLoading && (
+                <div className="mt-6 text-sm text-slate-400">Загружаем историю уведомлений…</div>
+              )}
+
+              {!isNotificationsLoading && groupedNotifications.length === 0 && (
+                <div className="mt-6 rounded-xl border border-slate-800 bg-slate-950/60 px-6 py-10 text-center text-sm text-slate-400">
+                  У вас пока нет уведомлений по выбранным фильтрам.
+                </div>
+              )}
+
+              <div className="mt-6 space-y-6">
+                {groupedNotifications.map((group) => (
+                  <div key={group.date} className="space-y-3">
+                    <div className="flex items-center gap-2 text-sm font-semibold text-slate-200">
+                      <span>{group.date}</span>
+                      <span className="h-px flex-1 bg-slate-800" />
+                    </div>
+                    <ul className="space-y-3">
+                      {group.items.map((notification) => (
+                        <li
+                          key={notification.id}
+                          className={`rounded-xl border px-4 py-3 transition ${
+                            notification.isRead
+                              ? 'border-slate-800 bg-slate-950/40'
+                              : 'border-secondary/40 bg-secondary/5'
+                          }`}
+                        >
+                          <div className="flex flex-wrap items-start justify-between gap-3">
+                            <div>
+                              <p className="text-sm font-semibold text-white">{notification.title}</p>
+                              <p className="mt-1 text-sm text-slate-300">{notification.description}</p>
+                              <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px] uppercase tracking-wide text-slate-500">
+                                <span>{notification.timeLabel}</span>
+                                {notification.channel && (
+                                  <span className="rounded-full border border-slate-700 px-2 py-0.5 text-[10px] text-slate-400">
+                                    {notification.channel}
+                                  </span>
+                                )}
+                                {notification.source && (
+                                  <span className="rounded-full border border-slate-700 px-2 py-0.5 text-[10px] text-slate-400">
+                                    {notification.source}
+                                  </span>
+                                )}
+                                {notification.importance === 'high' && (
+                                  <span className="flex items-center gap-1 rounded-full border border-amber-400 px-2 py-0.5 text-[10px] text-amber-200">
+                                    <ExclamationTriangleIcon className="h-3 w-3" /> Важно
+                                  </span>
+                                )}
+                              </div>
+                            </div>
+                            <div className="flex flex-col items-end gap-2 text-xs">
+                              <button
+                                type="button"
+                                onClick={() => markAsRead([notification.id])}
+                                disabled={notification.isRead || isMarking}
+                                className={`flex items-center gap-1 rounded-full px-3 py-1 font-semibold transition ${
+                                  notification.isRead
+                                    ? 'border border-slate-700 text-slate-500'
+                                    : 'border border-secondary/70 text-secondary hover:border-secondary hover:text-secondary/90'
+                                }`}
+                              >
+                                <CheckIcon className="h-4 w-4" />
+                                {notification.isRead ? 'Прочитано' : 'Отметить'}
+                              </button>
+                              <span className="text-slate-500">Создано: {notification.createdAtLabel}</span>
+                            </div>
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+
+              {hasMore && (
+                <div className="mt-8 flex justify-center">
+                  <button
+                    type="button"
+                    onClick={() => loadMore()}
+                    disabled={isFetchingMore}
+                    className="rounded-full border border-slate-700 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:border-secondary/60 hover:text-secondary disabled:cursor-not-allowed disabled:border-slate-800 disabled:text-slate-500"
+                  >
+                    {isFetchingMore ? 'Загружаем…' : 'Загрузить ещё'}
+                  </button>
+                </div>
+              )}
+            </section>
+          </section>
+        </div>
+      </main>
+    </>
+  );
+}

--- a/app/src/pages/slots.tsx
+++ b/app/src/pages/slots.tsx
@@ -11,6 +11,7 @@ import {
   UsersIcon
 } from '@heroicons/react/24/outline';
 
+import NotificationToggle from '@/components/profile/NotificationToggle';
 import { PROFESSION_OPTIONS } from '@/data/professions';
 import { SLOT_DATA, type Slot, type SlotParticipant, type SlotStatus } from '@/data/slots';
 
@@ -301,39 +302,6 @@ function SlotCard({
         )}
       </footer>
     </article>
-  );
-}
-
-interface NotificationToggleProps {
-  label: string;
-  description: string;
-  checked: boolean;
-  onToggle: () => void;
-}
-
-function NotificationToggle({ label, description, checked, onToggle }: NotificationToggleProps) {
-  return (
-    <div className="flex items-center justify-between gap-4 rounded-2xl border border-slate-800 bg-slate-950/70 p-4">
-      <div>
-        <p className="text-sm font-semibold text-white">{label}</p>
-        <p className="text-xs text-slate-400">{description}</p>
-      </div>
-      <button
-        type="button"
-        role="switch"
-        aria-checked={checked}
-        onClick={onToggle}
-        className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary/60 ${
-          checked ? 'bg-secondary/80' : 'bg-slate-700'
-        }`}
-      >
-        <span
-          className={`inline-block h-5 w-5 transform rounded-full bg-slate-950 transition ${
-            checked ? 'translate-x-5' : 'translate-x-1'
-          }`}
-        />
-      </button>
-    </div>
   );
 }
 
@@ -892,37 +860,43 @@ export default function SlotDashboardPage() {
 
           <div className="mt-6 grid gap-3 md:grid-cols-3">
             <NotificationToggle
+              channel="telegram"
               label="Telegram"
               description="Моментальные пуши в бота @supermock_slots, поддержка быстрых действий"
-              checked={notificationSettings.telegram}
+              enabled={notificationSettings.telegram}
               onToggle={() =>
                 setNotificationSettings((state) => ({
                   ...state,
                   telegram: !state.telegram
                 }))
               }
+              showMarkReadButton={false}
             />
             <NotificationToggle
+              channel="email"
               label="Email"
               description="Ежедневная сводка по свободным слотам и изменениям в расписании"
-              checked={notificationSettings.email}
+              enabled={notificationSettings.email}
               onToggle={() =>
                 setNotificationSettings((state) => ({
                   ...state,
                   email: !state.email
                 }))
               }
+              showMarkReadButton={false}
             />
             <NotificationToggle
+              channel="push"
               label="Push"
               description="Браузерные уведомления о том, что слот открылся или завершился"
-              checked={notificationSettings.push}
+              enabled={notificationSettings.push}
               onToggle={() =>
                 setNotificationSettings((state) => ({
                   ...state,
                   push: !state.push
                 }))
               }
+              showMarkReadButton={false}
             />
           </div>
 

--- a/server/src/modules/matching-notifications.ts
+++ b/server/src/modules/matching-notifications.ts
@@ -90,7 +90,9 @@ export function createMatchSchedulingHooks(options: { webhookUrl?: string | null
             payload: {
               ...payload,
               role: 'candidate'
-            }
+            },
+            source: 'matching',
+            importance: 'high'
           }).catch((error) => {
             console.error('Failed to create candidate match notification', error);
           })
@@ -106,7 +108,9 @@ export function createMatchSchedulingHooks(options: { webhookUrl?: string | null
             payload: {
               ...payload,
               role: 'interviewer'
-            }
+            },
+            source: 'matching',
+            importance: 'high'
           }).catch((error) => {
             console.error('Failed to create interviewer match notification', error);
           })

--- a/server/src/routes/notifications.route.ts
+++ b/server/src/routes/notifications.route.ts
@@ -20,7 +20,9 @@ const createNotificationSchema = z.object({
   type: z.string().min(1),
   channel: z.string().min(1).optional(),
   payload: z.record(z.any()).optional(),
-  metadata: z.record(z.any()).optional()
+  metadata: z.record(z.any()).optional(),
+  source: z.string().trim().min(1).optional(),
+  importance: z.enum(['low', 'normal', 'high']).optional()
 });
 
 const markReadSchema = z.object({

--- a/shared/src/types/realtime.ts
+++ b/shared/src/types/realtime.ts
@@ -60,24 +60,34 @@ export interface RealtimeSessionListQuery {
   activeOnly?: boolean;
 }
 
+export type NotificationChannel = 'in-app' | 'email' | 'telegram' | 'push' | string;
+
+export type NotificationImportance = 'low' | 'normal' | 'high';
+
+export type NotificationSource = 'matching' | 'system' | 'profile' | string;
+
 export interface NotificationDto {
   id: string;
   userId: string;
   type: string;
-  channel?: string | null;
+  channel?: NotificationChannel | null;
   payload?: Record<string, unknown>;
   readAt?: string | null;
   createdAt: string;
   updatedAt: string;
-  metadata?: Record<string, unknown>;
+  metadata?: Record<string, unknown> | null;
+  source?: NotificationSource;
+  importance?: NotificationImportance;
 }
 
 export interface CreateNotificationPayload {
   userId: string;
   type: string;
-  channel?: string;
+  channel?: NotificationChannel;
   payload?: Record<string, unknown>;
-  metadata?: Record<string, unknown>;
+  metadata?: Record<string, unknown> | null;
+  source?: NotificationSource;
+  importance?: NotificationImportance;
 }
 
 export interface MarkNotificationsReadPayload {


### PR DESCRIPTION
## Summary
- add API helpers to fetch/update user profiles and format notification payloads before streaming them over a reusable WebSocket subscription helper
- introduce a `useNotifications` hook and reusable `NotificationToggle` component that synchronize history, live updates, filters, and mark-as-read actions
- create the `/profile` notifications dashboard and wire notification metadata on the server so events include source/importance details

## Testing
- `pnpm --filter ./app lint`
- `pnpm lint` *(fails: server package has no ESLint configuration)*
- `pnpm type-check` *(fails: server package has pre-existing TypeScript errors)*
- `pnpm --filter ./app type-check` *(fails: app tests reference missing modules in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68cfe12bdf3c8327a514d3b4ccecd22b