### PR TITLE
Add global navigation bar with profile CTA

### DIFF
--- a/app/src/components/Layout/NavBar.tsx
+++ b/app/src/components/Layout/NavBar.tsx
@@ -1,0 +1,81 @@
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useCallback } from 'react';
+
+import { useAuth } from '@/store/useAuth';
+
+const navigationLinks = [
+  { href: '/', label: 'Главная' },
+  { href: '/slots', label: 'Слоты' },
+  { href: '/interviewer', label: 'Интервьюеру' },
+  { href: '/profile', label: 'Профиль' }
+];
+
+export default function NavBar() {
+  const router = useRouter();
+  const isAuthenticated = useAuth((state) => state.isAuthenticated);
+  const user = useAuth((state) => state.user);
+  const logout = useAuth((state) => state.logout);
+
+  const handleLogout = useCallback(() => {
+    logout();
+    if (router.pathname !== '/') {
+      void router.push('/');
+    }
+  }, [logout, router]);
+
+  return (
+    <header className="sticky top-0 z-40 border-b border-slate-800 bg-slate-950/85 backdrop-blur">
+      <div className="mx-auto flex w-full max-w-6xl items-center justify-between gap-4 px-4 py-3">
+        <Link href="/" className="text-base font-semibold text-white transition hover:text-secondary">
+          SuperMock
+        </Link>
+
+        <nav className="flex items-center gap-2 md:gap-4">
+          {navigationLinks.map((link) => {
+            const isActive = router.pathname === link.href;
+
+            return (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={`rounded-md px-3 py-2 text-sm font-medium transition ${
+                  isActive
+                    ? 'bg-secondary/15 text-secondary'
+                    : 'text-slate-300 hover:bg-slate-900 hover:text-white'
+                }`}
+                aria-current={isActive ? 'page' : undefined}
+              >
+                {link.label}
+              </Link>
+            );
+          })}
+        </nav>
+
+        <div className="flex items-center gap-3">
+          {isAuthenticated && user ? (
+            <>
+              <span className="hidden text-xs text-slate-400 sm:inline" title={user.email}>
+                {user.email}
+              </span>
+              <button
+                type="button"
+                onClick={handleLogout}
+                className="rounded-md border border-slate-700 px-3 py-2 text-xs font-semibold text-slate-200 transition hover:bg-slate-900"
+              >
+                Выйти
+              </button>
+            </>
+          ) : (
+            <Link
+              href="/onboarding"
+              className="rounded-md border border-secondary/40 px-3 py-2 text-xs font-semibold text-secondary transition hover:bg-secondary/10"
+            >
+              Войти
+            </Link>
+          )}
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/app/src/pages/_app.tsx
+++ b/app/src/pages/_app.tsx
@@ -2,6 +2,7 @@ import type { AppProps } from 'next/app';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useState } from 'react';
 
+import NavBar from '@/components/Layout/NavBar';
 import '@/styles/globals.css';
 
 export default function SuperMockDesktopApp({ Component, pageProps }: AppProps) {
@@ -9,7 +10,10 @@ export default function SuperMockDesktopApp({ Component, pageProps }: AppProps) 
 
   return (
     <QueryClientProvider client={queryClient}>
-      <Component {...pageProps} />
+      <div className="min-h-screen bg-slate-950 text-slate-50">
+        <NavBar />
+        <Component {...pageProps} />
+      </div>
     </QueryClientProvider>
   );
 }

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -1,6 +1,8 @@
 import Head from 'next/head';
 import Link from 'next/link';
 
+import { useAuth } from '@/store/useAuth';
+
 const features = [
   {
     title: 'Real-time interviews',
@@ -30,6 +32,8 @@ const features = [
 ];
 
 export default function HomePage() {
+  const isAuthenticated = useAuth((state) => state.isAuthenticated);
+
   return (
     <>
       <Head>
@@ -54,6 +58,14 @@ export default function HomePage() {
             >
               Open slots dashboard
             </Link>
+            {isAuthenticated && (
+              <Link
+                href="/profile"
+                className="rounded-lg border border-secondary/40 px-5 py-2 text-sm font-semibold text-secondary shadow shadow-secondary/30 transition hover:bg-secondary/10"
+              >
+                Перейти в профиль
+              </Link>
+            )}
             <span className="text-xs text-slate-500">
               Tip: browse available slots, filter by language and tools, and join interviews on `/slots`
             </span>


### PR DESCRIPTION
## Summary
- add a shared navigation bar with key routes and authentication actions including the profile link
- wrap the desktop app with the navigation so the profile link is available globally
- show a profile CTA on the home page when the user is authenticated

## Testing
- pnpm --filter ./app lint
- pnpm --filter ./app type-check

------
https://chatgpt.com/codex/tasks/task_e_68d09cdb7aa48327853ae53035e4edda