### PR TITLE
feat: enhance profile page capabilities

### DIFF
--- a/app/src/pages/profile.tsx
+++ b/app/src/pages/profile.tsx
@@ -1,14 +1,147 @@
 import Head from 'next/head';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
+import { ChangeEvent, FormEvent, useEffect, useRef, useState } from 'react';
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { deleteAccount, exportUserData } from '@/lib/api';
+import {
+  DEFAULT_NOTIFICATION_PREFERENCES,
+  changePassword,
+  deleteAccount,
+  exportUserData,
+  fetchActivityHistory,
+  fetchNotificationPreferences,
+  fetchUserProfile,
+  updateNotificationPreferences,
+  updateProfile,
+  uploadAvatar,
+  type ActivityEntryDto,
+  type ActivityHistoryResponse,
+  type NotificationPreferencesDto,
+  type ProfileRecord
+} from '@/lib/api';
 import { useAuth } from '@/store/useAuth';
+
+type ProfileFormState = {
+  displayName: string;
+  bio: string;
+  locale: string;
+  timezone: string;
+};
+
+type PasswordFormState = {
+  currentPassword: string;
+  newPassword: string;
+  confirmPassword: string;
+};
+
+function normalizeNotificationPreferences(value: unknown): NotificationPreferencesDto {
+  const base: NotificationPreferencesDto = { ...DEFAULT_NOTIFICATION_PREFERENCES };
+
+  if (value && typeof value === 'object') {
+    (Object.keys(base) as Array<keyof NotificationPreferencesDto>).forEach((key) => {
+      const candidate = (value as Record<string, unknown>)[key];
+      if (typeof candidate === 'boolean') {
+        base[key] = candidate;
+      }
+    });
+  }
+
+  return base;
+}
+
+function cloneProfileRecord(value: ProfileRecord | null | undefined): ProfileRecord {
+  if (!value) {
+    return {} as ProfileRecord;
+  }
+
+  return { ...(value as Record<string, unknown>) } as ProfileRecord;
+}
+
+function getProfileString(record: ProfileRecord | null | undefined, key: keyof ProfileFormState) {
+  if (!record) {
+    return '';
+  }
+
+  const candidate = (record as Record<string, unknown>)[key];
+  return typeof candidate === 'string' ? candidate : '';
+}
+
+function buildProfileUpdate(
+  current: ProfileRecord | null,
+  form: ProfileFormState,
+  preferences: NotificationPreferencesDto
+): ProfileRecord {
+  const next: ProfileRecord = { ...(current ?? {}) };
+  const displayName = form.displayName.trim();
+  const timezone = form.timezone.trim();
+  const locale = form.locale.trim();
+  const bio = form.bio.trim();
+
+  next.displayName = displayName || null;
+  next.timezone = timezone || null;
+  next.locale = locale || null;
+  next.bio = bio || null;
+  next.notificationPreferences = { ...preferences };
+
+  return next;
+}
+
+function toReadableActivityType(type: string) {
+  return type
+    .replace(/[_-]+/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function formatDateTime(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return date.toLocaleString('ru-RU', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit'
+  });
+}
 
 export default function ProfilePage() {
   const router = useRouter();
+  const queryClient = useQueryClient();
+
   const user = useAuth((state) => state.user);
   const isAuthenticated = useAuth((state) => state.isAuthenticated);
+  const updateUserProfile = useAuth((state) => state.updateUserProfile);
+  const setUserFromDto = useAuth((state) => state.setUserFromDto);
+
+  const [profileForm, setProfileForm] = useState<ProfileFormState>({
+    displayName: '',
+    bio: '',
+    locale: '',
+    timezone: ''
+  });
+  const [profileDirty, setProfileDirty] = useState(false);
+  const [profileMessage, setProfileMessage] = useState<string | null>(null);
+  const [profileError, setProfileError] = useState<string | null>(null);
+
+  const [currentProfile, setCurrentProfile] = useState<ProfileRecord | null>(null);
+
+  const [notificationForm, setNotificationForm] = useState<NotificationPreferencesDto>({
+    ...DEFAULT_NOTIFICATION_PREFERENCES
+  });
+  const [notificationDirty, setNotificationDirty] = useState(false);
+  const [notificationMessage, setNotificationMessage] = useState<string | null>(null);
+  const [notificationError, setNotificationError] = useState<string | null>(null);
+
+  const [passwordForm, setPasswordForm] = useState<PasswordFormState>({
+    currentPassword: '',
+    newPassword: '',
+    confirmPassword: ''
+  });
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [passwordMessage, setPasswordMessage] = useState<string | null>(null);
 
   const [isExporting, setIsExporting] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
@@ -17,6 +150,200 @@ export default function ProfilePage() {
   const [token, setToken] = useState('');
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const avatarObjectUrlRef = useRef<string | null>(null);
+  const [avatarPreview, setAvatarPreview] = useState<string | null>(null);
+  const [avatarMessage, setAvatarMessage] = useState<string | null>(null);
+  const [avatarError, setAvatarError] = useState<string | null>(null);
+
+  const profileQuery = useQuery({
+    queryKey: ['profile', user?.id],
+    queryFn: () => fetchUserProfile(user!.id),
+    enabled: Boolean(user?.id),
+    staleTime: 30_000
+  });
+
+  const notificationQuery = useQuery({
+    queryKey: ['profile', user?.id, 'notification-preferences'],
+    queryFn: () => fetchNotificationPreferences(user!.id),
+    enabled: Boolean(user?.id)
+  });
+
+  const activityQuery = useInfiniteQuery<ActivityHistoryResponse, Error>({
+    queryKey: ['profile', user?.id ?? 'self', 'activity'],
+    queryFn: ({ pageParam }) =>
+      fetchActivityHistory(user!.id, {
+        cursor: (pageParam as string | undefined) ?? undefined,
+        limit: 10
+      }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) =>
+      lastPage.hasMore && lastPage.nextCursor ? lastPage.nextCursor : undefined,
+    enabled: Boolean(user?.id)
+  });
+
+  useEffect(() => {
+    if (!user) {
+      setProfileForm({ displayName: '', bio: '', locale: '', timezone: '' });
+      setProfileDirty(false);
+      setCurrentProfile(null);
+      setNotificationForm({ ...DEFAULT_NOTIFICATION_PREFERENCES });
+      setNotificationDirty(false);
+      setAvatarPreview(null);
+      setAvatarMessage(null);
+      setAvatarError(null);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (!profileQuery.data) {
+      return;
+    }
+
+    const profileRecord = cloneProfileRecord(profileQuery.data.profile as ProfileRecord | null);
+    setCurrentProfile(profileRecord);
+
+    if (!profileDirty) {
+      setProfileForm({
+        displayName: getProfileString(profileRecord, 'displayName'),
+        bio: getProfileString(profileRecord, 'bio'),
+        locale: getProfileString(profileRecord, 'locale'),
+        timezone: getProfileString(profileRecord, 'timezone')
+      });
+    }
+
+    if (!notificationQuery.isSuccess && !notificationDirty) {
+      setNotificationForm(normalizeNotificationPreferences(profileRecord.notificationPreferences));
+    }
+
+    setAvatarPreview(profileQuery.data.avatarUrl ?? null);
+  }, [profileQuery.data, profileDirty, notificationQuery.isSuccess, notificationDirty]);
+
+  useEffect(() => {
+    if (!notificationQuery.data) {
+      return;
+    }
+
+    const preferences = normalizeNotificationPreferences(notificationQuery.data.preferences);
+    setNotificationForm(preferences);
+    setNotificationDirty(false);
+    setNotificationMessage(null);
+    setNotificationError(null);
+    setCurrentProfile((prev) => {
+      const next = { ...(prev ?? {}) } as ProfileRecord;
+      next.notificationPreferences = { ...preferences };
+      return next;
+    });
+  }, [notificationQuery.data]);
+
+  useEffect(() => {
+    return () => {
+      if (avatarObjectUrlRef.current) {
+        URL.revokeObjectURL(avatarObjectUrlRef.current);
+        avatarObjectUrlRef.current = null;
+      }
+    };
+  }, []);
+
+  const updateProfileMutation = useMutation({
+    mutationFn: (profile: ProfileRecord | null) => updateProfile(user!.id, { profile }),
+    onSuccess: (updatedUser) => {
+      queryClient.setQueryData(['profile', user!.id], updatedUser);
+      setUserFromDto(updatedUser);
+
+      const profileRecord = cloneProfileRecord(updatedUser.profile as ProfileRecord | null);
+      setCurrentProfile(profileRecord);
+      setProfileForm({
+        displayName: getProfileString(profileRecord, 'displayName'),
+        bio: getProfileString(profileRecord, 'bio'),
+        locale: getProfileString(profileRecord, 'locale'),
+        timezone: getProfileString(profileRecord, 'timezone')
+      });
+
+      const preferences = normalizeNotificationPreferences(profileRecord.notificationPreferences);
+      setNotificationForm(preferences);
+      setNotificationDirty(false);
+      queryClient.setQueryData(['profile', user!.id, 'notification-preferences'], {
+        preferences,
+        updatedAt: new Date().toISOString()
+      });
+
+      setProfileDirty(false);
+      setProfileMessage('Профиль обновлён.');
+      setProfileError(null);
+    },
+    onError: (error) => {
+      setProfileError(error instanceof Error ? error.message : 'Не удалось обновить профиль');
+      setProfileMessage(null);
+    }
+  });
+
+  const uploadAvatarMutation = useMutation({
+    mutationFn: (file: File) => uploadAvatar(user!.id, file),
+    onSuccess: (result) => {
+      if (avatarObjectUrlRef.current) {
+        URL.revokeObjectURL(avatarObjectUrlRef.current);
+        avatarObjectUrlRef.current = null;
+      }
+
+      setAvatarPreview(result.avatarUrl);
+      setAvatarMessage('Аватар обновлён.');
+      setAvatarError(null);
+      updateUserProfile({ avatarUrl: result.avatarUrl });
+      queryClient.setQueryData(['profile', user!.id], (existing) => {
+        if (!existing) {
+          return existing;
+        }
+        return { ...existing, avatarUrl: result.avatarUrl };
+      });
+    },
+    onError: (error) => {
+      setAvatarError(error instanceof Error ? error.message : 'Не удалось загрузить аватар');
+      setAvatarMessage(null);
+    }
+  });
+
+  const notificationMutation = useMutation({
+    mutationFn: (preferences: NotificationPreferencesDto) =>
+      updateNotificationPreferences(user!.id, preferences),
+    onSuccess: (response) => {
+      const preferences = normalizeNotificationPreferences(response.preferences);
+      setNotificationForm(preferences);
+      setNotificationDirty(false);
+      setNotificationMessage('Настройки уведомлений обновлены.');
+      setNotificationError(null);
+
+      const nextProfile = { ...(currentProfile ?? {}) } as ProfileRecord;
+      nextProfile.notificationPreferences = { ...preferences };
+      setCurrentProfile(nextProfile);
+      updateUserProfile({ notificationPreferences: preferences, profile: nextProfile });
+
+      queryClient.setQueryData(['profile', user!.id, 'notification-preferences'], {
+        preferences,
+        updatedAt: response.updatedAt ?? new Date().toISOString()
+      });
+    },
+    onError: (error) => {
+      setNotificationError(
+        error instanceof Error ? error.message : 'Не удалось обновить настройки уведомлений'
+      );
+      setNotificationMessage(null);
+    }
+  });
+
+  const changePasswordMutation = useMutation({
+    mutationFn: (payload: { currentPassword: string; newPassword: string }) =>
+      changePassword(user!.id, payload),
+    onSuccess: () => {
+      setPasswordForm({ currentPassword: '', newPassword: '', confirmPassword: '' });
+      setPasswordMessage('Пароль обновлён.');
+      setPasswordError(null);
+    },
+    onError: (error) => {
+      setPasswordError(error instanceof Error ? error.message : 'Не удалось сменить пароль');
+      setPasswordMessage(null);
+    }
+  });
 
   const handleExport = async () => {
     if (!user) {
@@ -47,6 +374,132 @@ export default function ProfilePage() {
     } finally {
       setIsExporting(false);
     }
+  };
+
+  const handleProfileSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!user) {
+      setProfileError('Не удалось определить пользователя.');
+      return;
+    }
+
+    const nextProfile = buildProfileUpdate(currentProfile, profileForm, notificationForm);
+    setProfileMessage(null);
+    setProfileError(null);
+    updateProfileMutation.mutate(nextProfile);
+  };
+
+  const handleProfileReset = () => {
+    setProfileForm({
+      displayName: getProfileString(currentProfile, 'displayName'),
+      bio: getProfileString(currentProfile, 'bio'),
+      locale: getProfileString(currentProfile, 'locale'),
+      timezone: getProfileString(currentProfile, 'timezone')
+    });
+    setProfileDirty(false);
+    setProfileMessage(null);
+    setProfileError(null);
+  };
+
+  const handleAvatarChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+
+    if (!file) {
+      return;
+    }
+
+    if (!file.type.startsWith('image/')) {
+      setAvatarError('Поддерживаются только изображения форматов PNG, JPG или WEBP.');
+      return;
+    }
+
+    if (avatarObjectUrlRef.current) {
+      URL.revokeObjectURL(avatarObjectUrlRef.current);
+      avatarObjectUrlRef.current = null;
+    }
+
+    const previewUrl = URL.createObjectURL(file);
+    avatarObjectUrlRef.current = previewUrl;
+    setAvatarPreview(previewUrl);
+    setAvatarMessage(null);
+    setAvatarError(null);
+
+    if (!user) {
+      setAvatarError('Не удалось определить пользователя.');
+      return;
+    }
+
+    uploadAvatarMutation.mutate(file);
+  };
+
+  const handleNotificationToggle = (key: keyof NotificationPreferencesDto) => {
+    setNotificationForm((prev) => {
+      const next = { ...prev, [key]: !prev[key] } as NotificationPreferencesDto;
+      setNotificationDirty(true);
+      setNotificationMessage(null);
+      setNotificationError(null);
+      return next;
+    });
+  };
+
+  const handleNotificationReset = () => {
+    const base = normalizeNotificationPreferences(currentProfile?.notificationPreferences);
+    setNotificationForm(base);
+    setNotificationDirty(false);
+    setNotificationMessage(null);
+    setNotificationError(null);
+  };
+
+  const handleNotificationSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!user) {
+      setNotificationError('Не удалось определить пользователя.');
+      return;
+    }
+
+    setNotificationError(null);
+    setNotificationMessage(null);
+    notificationMutation.mutate({ ...notificationForm });
+  };
+
+  const handlePasswordSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setPasswordError(null);
+    setPasswordMessage(null);
+
+    if (!user) {
+      setPasswordError('Не удалось определить пользователя.');
+      return;
+    }
+
+    const currentValue = passwordForm.currentPassword.trim();
+    const newValue = passwordForm.newPassword.trim();
+    const confirmValue = passwordForm.confirmPassword.trim();
+
+    if (!currentValue || !newValue || !confirmValue) {
+      setPasswordError('Заполните все поля формы.');
+      return;
+    }
+
+    if (newValue.length < 8) {
+      setPasswordError('Новый пароль должен содержать минимум 8 символов.');
+      return;
+    }
+
+    if (newValue !== confirmValue) {
+      setPasswordError('Подтверждение пароля не совпадает.');
+      return;
+    }
+
+    if (currentValue === newValue) {
+      setPasswordError('Новый пароль должен отличаться от текущего.');
+      return;
+    }
+
+    changePasswordMutation.mutate({ currentPassword: currentValue, newPassword: newValue });
   };
 
   const openDeleteModal = () => {
@@ -97,6 +550,9 @@ export default function ProfilePage() {
     }
   };
 
+  const activityItems =
+    activityQuery.data?.pages.flatMap((page: ActivityHistoryResponse) => page.items) ?? [];
+
   return (
     <>
       <Head>
@@ -106,11 +562,367 @@ export default function ProfilePage() {
         <header className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-lg shadow-slate-950/40">
           <h1 className="text-2xl font-semibold text-white">Профиль</h1>
           {isAuthenticated && user ? (
-            <p className="mt-2 text-sm text-slate-400">Вход выполнен для {user.email}</p>
+            <p className="mt-2 text-sm text-slate-400">
+              Вход выполнен для {user.email}
+              {user.displayName ? ` · ${user.displayName}` : ''}
+            </p>
           ) : (
             <p className="mt-2 text-sm text-slate-400">Авторизуйтесь, чтобы управлять личными данными.</p>
           )}
         </header>
+
+        <section className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-lg shadow-slate-950/40">
+          <h2 className="text-lg font-semibold text-white">Настройки профиля</h2>
+          {profileQuery.isError && (
+            <p className="mt-3 text-sm text-red-400" role="alert">
+              Не удалось загрузить профиль: {profileQuery.error instanceof Error ? profileQuery.error.message : 'ошибка' }
+            </p>
+          )}
+          <form onSubmit={handleProfileSubmit} className="mt-4 grid gap-6 md:grid-cols-[auto,1fr]">
+            <div className="flex flex-col items-center gap-3">
+              <div className="relative h-24 w-24 overflow-hidden rounded-full border border-slate-700 bg-slate-950 shadow-inner shadow-slate-950/40">
+                {avatarPreview ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={avatarPreview} alt="Аватар пользователя" className="h-full w-full object-cover" />
+                ) : (
+                  <div className="flex h-full w-full items-center justify-center text-sm text-slate-500">Нет аватара</div>
+                )}
+              </div>
+              <label className="inline-flex cursor-pointer items-center justify-center rounded-md border border-slate-700 px-3 py-1.5 text-xs font-semibold text-slate-200 transition hover:border-slate-500 hover:text-white">
+                <input
+                  type="file"
+                  accept="image/png,image/jpeg,image/jpg,image/webp"
+                  className="hidden"
+                  onChange={handleAvatarChange}
+                  disabled={!user || uploadAvatarMutation.isPending}
+                />
+                {uploadAvatarMutation.isPending ? 'Загрузка…' : 'Обновить аватар'}
+              </label>
+              {avatarMessage && <p className="text-xs text-emerald-300">{avatarMessage}</p>}
+              {avatarError && (
+                <p className="text-xs text-red-400" role="alert">
+                  {avatarError}
+                </p>
+              )}
+            </div>
+            <div className="space-y-4">
+              <div>
+                <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="profile-display-name">
+                  Имя и фамилия
+                </label>
+                <input
+                  id="profile-display-name"
+                  type="text"
+                  value={profileForm.displayName}
+                  onChange={(event) => {
+                    setProfileForm((prev) => ({ ...prev, displayName: event.target.value }));
+                    setProfileDirty(true);
+                    setProfileMessage(null);
+                    setProfileError(null);
+                  }}
+                  placeholder="Например, Анастасия Иванова"
+                  disabled={!user || updateProfileMutation.isPending}
+                  className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white shadow-inner shadow-slate-950/40 focus:border-secondary focus:outline-none focus:ring-2 focus:ring-secondary/60"
+                />
+              </div>
+              <div className="grid gap-4 md:grid-cols-2">
+                <div>
+                  <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="profile-timezone">
+                    Часовой пояс
+                  </label>
+                <input
+                  id="profile-timezone"
+                  type="text"
+                  value={profileForm.timezone}
+                  onChange={(event) => {
+                    setProfileForm((prev) => ({ ...prev, timezone: event.target.value }));
+                    setProfileDirty(true);
+                    setProfileMessage(null);
+                    setProfileError(null);
+                  }}
+                    placeholder="Например, Europe/Moscow"
+                    disabled={!user || updateProfileMutation.isPending}
+                    className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white shadow-inner shadow-slate-950/40 focus:border-secondary focus:outline-none focus:ring-2 focus:ring-secondary/60"
+                  />
+                </div>
+                <div>
+                  <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="profile-locale">
+                    Язык интерфейса
+                  </label>
+                <input
+                  id="profile-locale"
+                  type="text"
+                  value={profileForm.locale}
+                  onChange={(event) => {
+                    setProfileForm((prev) => ({ ...prev, locale: event.target.value }));
+                    setProfileDirty(true);
+                    setProfileMessage(null);
+                    setProfileError(null);
+                  }}
+                    placeholder="Например, ru-RU"
+                    disabled={!user || updateProfileMutation.isPending}
+                    className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white shadow-inner shadow-slate-950/40 focus:border-secondary focus:outline-none focus:ring-2 focus:ring-secondary/60"
+                  />
+                </div>
+              </div>
+              <div>
+                <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="profile-bio">
+                  Кратко о себе
+                </label>
+                <textarea
+                  id="profile-bio"
+                  value={profileForm.bio}
+                  onChange={(event) => {
+                    setProfileForm((prev) => ({ ...prev, bio: event.target.value }));
+                    setProfileDirty(true);
+                    setProfileMessage(null);
+                    setProfileError(null);
+                  }}
+                  placeholder="Расскажите, чем вы занимаетесь"
+                  disabled={!user || updateProfileMutation.isPending}
+                  rows={4}
+                  className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white shadow-inner shadow-slate-950/40 focus:border-secondary focus:outline-none focus:ring-2 focus:ring-secondary/60"
+                />
+              </div>
+              {profileError && (
+                <p className="text-sm text-red-400" role="alert">
+                  {profileError}
+                </p>
+              )}
+              {profileMessage && <p className="text-sm text-emerald-300">{profileMessage}</p>}
+              <div className="flex justify-end gap-3">
+                <button
+                  type="button"
+                  onClick={handleProfileReset}
+                  disabled={!user || updateProfileMutation.isPending}
+                  className="rounded-md border border-slate-600 px-4 py-2 text-sm font-medium text-slate-200 transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  Сбросить
+                </button>
+                <button
+                  type="submit"
+                  disabled={!user || updateProfileMutation.isPending || !profileDirty}
+                  className="rounded-md bg-secondary px-4 py-2 text-sm font-semibold text-slate-950 shadow shadow-secondary/40 transition hover:bg-secondary/90 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {updateProfileMutation.isPending ? 'Сохраняем…' : 'Сохранить изменения'}
+                </button>
+              </div>
+            </div>
+          </form>
+        </section>
+
+        <section className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-lg shadow-slate-950/40">
+          <h2 className="text-lg font-semibold text-white">Настройки уведомлений</h2>
+          {notificationQuery.isLoading && (
+            <p className="mt-3 text-sm text-slate-400">Загружаем настройки…</p>
+          )}
+          {notificationQuery.isError && (
+            <p className="mt-3 text-sm text-red-400" role="alert">
+              Не удалось загрузить настройки уведомлений.
+            </p>
+          )}
+          <form onSubmit={handleNotificationSubmit} className="mt-4 space-y-4">
+            <div className="space-y-3">
+              <label className="flex items-start gap-3">
+                <input
+                  type="checkbox"
+                  className="mt-1 h-4 w-4 rounded border-slate-600 bg-slate-950 text-secondary focus:ring-secondary/60"
+                  checked={notificationForm.upcomingSessions}
+                  onChange={() => handleNotificationToggle('upcomingSessions')}
+                  disabled={!user || notificationMutation.isPending}
+                />
+                <span className="text-sm text-slate-200">
+                  Напоминать о предстоящих интервью и репетициях
+                </span>
+              </label>
+              <label className="flex items-start gap-3">
+                <input
+                  type="checkbox"
+                  className="mt-1 h-4 w-4 rounded border-slate-600 bg-slate-950 text-secondary focus:ring-secondary/60"
+                  checked={notificationForm.newMatches}
+                  onChange={() => handleNotificationToggle('newMatches')}
+                  disabled={!user || notificationMutation.isPending}
+                />
+                <span className="text-sm text-slate-200">
+                  Получать уведомления о новых подборках и совпадениях
+                </span>
+              </label>
+              <label className="flex items-start gap-3">
+                <input
+                  type="checkbox"
+                  className="mt-1 h-4 w-4 rounded border-slate-600 bg-slate-950 text-secondary focus:ring-secondary/60"
+                  checked={notificationForm.productUpdates}
+                  onChange={() => handleNotificationToggle('productUpdates')}
+                  disabled={!user || notificationMutation.isPending}
+                />
+                <span className="text-sm text-slate-200">Новости платформы и обновления продукта</span>
+              </label>
+              <label className="flex items-start gap-3">
+                <input
+                  type="checkbox"
+                  className="mt-1 h-4 w-4 rounded border-slate-600 bg-slate-950 text-secondary focus:ring-secondary/60"
+                  checked={notificationForm.securityAlerts}
+                  onChange={() => handleNotificationToggle('securityAlerts')}
+                  disabled={!user || notificationMutation.isPending}
+                />
+                <span className="text-sm text-slate-200">Предупреждения о безопасности и входах в аккаунт</span>
+              </label>
+            </div>
+            {notificationError && (
+              <p className="text-sm text-red-400" role="alert">
+                {notificationError}
+              </p>
+            )}
+            {notificationMessage && <p className="text-sm text-emerald-300">{notificationMessage}</p>}
+            <div className="flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={handleNotificationReset}
+                disabled={!user || notificationMutation.isPending}
+                className="rounded-md border border-slate-600 px-4 py-2 text-sm font-medium text-slate-200 transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                Сбросить
+              </button>
+              <button
+                type="submit"
+                disabled={!user || notificationMutation.isPending || !notificationDirty}
+                className="rounded-md bg-secondary px-4 py-2 text-sm font-semibold text-slate-950 shadow shadow-secondary/40 transition hover:bg-secondary/90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {notificationMutation.isPending ? 'Сохраняем…' : 'Обновить настройки'}
+              </button>
+            </div>
+          </form>
+        </section>
+
+        <section className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-lg shadow-slate-950/40">
+          <h2 className="text-lg font-semibold text-white">Смена пароля</h2>
+          <form onSubmit={handlePasswordSubmit} className="mt-4 space-y-4">
+            <div>
+              <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="password-current">
+                Текущий пароль
+              </label>
+              <input
+                id="password-current"
+                type="password"
+                autoComplete="current-password"
+                value={passwordForm.currentPassword}
+                onChange={(event) => {
+                  setPasswordForm((prev) => ({ ...prev, currentPassword: event.target.value }));
+                  setPasswordError(null);
+                  setPasswordMessage(null);
+                }}
+                disabled={!user || changePasswordMutation.isPending}
+                className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white shadow-inner shadow-slate-950/40 focus:border-secondary focus:outline-none focus:ring-2 focus:ring-secondary/60"
+              />
+            </div>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div>
+                <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="password-new">
+                  Новый пароль
+                </label>
+                <input
+                  id="password-new"
+                  type="password"
+                  autoComplete="new-password"
+                  value={passwordForm.newPassword}
+                  onChange={(event) => {
+                    setPasswordForm((prev) => ({ ...prev, newPassword: event.target.value }));
+                    setPasswordError(null);
+                    setPasswordMessage(null);
+                  }}
+                  disabled={!user || changePasswordMutation.isPending}
+                  className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white shadow-inner shadow-slate-950/40 focus:border-secondary focus:outline-none focus:ring-2 focus:ring-secondary/60"
+                />
+              </div>
+              <div>
+                <label className="text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="password-confirm">
+                  Подтверждение
+                </label>
+                <input
+                  id="password-confirm"
+                  type="password"
+                  autoComplete="new-password"
+                  value={passwordForm.confirmPassword}
+                  onChange={(event) => {
+                    setPasswordForm((prev) => ({ ...prev, confirmPassword: event.target.value }));
+                    setPasswordError(null);
+                    setPasswordMessage(null);
+                  }}
+                  disabled={!user || changePasswordMutation.isPending}
+                  className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white shadow-inner shadow-slate-950/40 focus:border-secondary focus:outline-none focus:ring-2 focus:ring-secondary/60"
+                />
+              </div>
+            </div>
+            {passwordError && (
+              <p className="text-sm text-red-400" role="alert">
+                {passwordError}
+              </p>
+            )}
+            {passwordMessage && <p className="text-sm text-emerald-300">{passwordMessage}</p>}
+            <div className="flex justify-end">
+              <button
+                type="submit"
+                disabled={!user || changePasswordMutation.isPending}
+                className="rounded-md bg-secondary px-4 py-2 text-sm font-semibold text-slate-950 shadow shadow-secondary/40 transition hover:bg-secondary/90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {changePasswordMutation.isPending ? 'Обновляем…' : 'Сменить пароль'}
+              </button>
+            </div>
+          </form>
+        </section>
+
+        <section className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-lg shadow-slate-950/40">
+          <h2 className="text-lg font-semibold text-white">История активности</h2>
+          {!isAuthenticated || !user ? (
+            <p className="mt-3 text-sm text-slate-400">Авторизуйтесь, чтобы увидеть историю действий.</p>
+          ) : activityQuery.isLoading ? (
+            <p className="mt-3 text-sm text-slate-400">Загружаем события…</p>
+          ) : activityQuery.isError ? (
+            <p className="mt-3 text-sm text-red-400" role="alert">
+              Не удалось загрузить историю активности.
+            </p>
+          ) : activityItems.length === 0 ? (
+            <p className="mt-3 text-sm text-slate-400">История активности пока пуста.</p>
+          ) : (
+            <ul className="mt-4 space-y-3">
+              {activityItems.map((entry: ActivityEntryDto) => (
+                <li
+                  key={entry.id}
+                  className="rounded-xl border border-slate-800 bg-slate-950/60 p-4 shadow shadow-slate-950/30"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <span className="text-sm font-semibold text-white">
+                      {entry.title ?? toReadableActivityType(entry.type)}
+                    </span>
+                    <time className="text-xs text-slate-500" dateTime={entry.createdAt}>
+                      {formatDateTime(entry.createdAt)}
+                    </time>
+                  </div>
+                  {entry.description && (
+                    <p className="mt-2 text-sm text-slate-300">{entry.description}</p>
+                  )}
+                  {entry.metadata && Object.keys(entry.metadata).length > 0 && (
+                    <pre className="mt-3 max-h-40 overflow-y-auto rounded-md border border-slate-800 bg-slate-950/80 p-3 text-xs text-slate-400">
+                      {JSON.stringify(entry.metadata, null, 2)}
+                    </pre>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+          {activityQuery.hasNextPage && (
+            <div className="mt-4 flex justify-end">
+              <button
+                type="button"
+                onClick={() => activityQuery.fetchNextPage()}
+                disabled={activityQuery.isFetchingNextPage}
+                className="rounded-md border border-slate-600 px-4 py-2 text-sm font-medium text-slate-200 transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {activityQuery.isFetchingNextPage ? 'Загружаем…' : 'Показать ещё'}
+              </button>
+            </div>
+          )}
+        </section>
 
         <section className="rounded-2xl border border-slate-800 bg-slate-900/70 p-6 shadow-lg shadow-slate-950/40">
           <h2 className="text-lg font-semibold text-white">Управление данными</h2>
@@ -141,8 +953,7 @@ export default function ProfilePage() {
           <div className="mt-6 rounded-lg border border-amber-500/30 bg-amber-500/10 p-4 text-sm text-amber-100">
             <p className="font-semibold">Удаление аккаунта</p>
             <p className="mt-2 text-amber-100/80">
-              Все данные, включая анкеты и уведомления, будут безвозвратно удалены. Для подтверждения требуется пароль или
-              одноразовый токен подтверждения.
+              Все данные, включая анкеты и уведомления, будут безвозвратно удалены. Для подтверждения требуется пароль или одноразовый токен подтверждения.
             </p>
             <div className="mt-4 flex flex-wrap gap-3">
               <button

--- a/app/src/store/useAuth.ts
+++ b/app/src/store/useAuth.ts
@@ -1,18 +1,102 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 
+import type { UserDto } from '../../../shared/src/types/user.js';
+
+interface NotificationPreferencesState {
+  upcomingSessions: boolean;
+  newMatches: boolean;
+  productUpdates: boolean;
+  securityAlerts: boolean;
+}
+
+const DEFAULT_NOTIFICATION_PREFERENCES: NotificationPreferencesState = {
+  upcomingSessions: true,
+  newMatches: true,
+  productUpdates: false,
+  securityAlerts: true,
+};
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  role: string;
+  emailVerified?: boolean;
+  emailVerifiedAt?: string | null;
+  avatarUrl?: string | null;
+  displayName?: string | null;
+  locale?: string | null;
+  timezone?: string | null;
+  profile?: Record<string, unknown> | null;
+  notificationPreferences: NotificationPreferencesState;
+}
+
 interface AuthState {
   accessToken: string | null;
-  user: {
-    id: string;
-    email: string;
-    role: string;
-    emailVerified: boolean;
-  } | null;
+  user: AuthUser | null;
   isAuthenticated: boolean;
   login: (email: string, password: string) => Promise<void>;
   logout: () => void;
-  setAuthData: (accessToken: string, user: AuthState['user']) => void;
+  setAuthData: (accessToken: string, user: UserDto | AuthUser) => void;
+  updateUserProfile: (updates: Partial<AuthUser>) => void;
+  setUserFromDto: (user: UserDto) => void;
+}
+
+function resolveNotificationPreferences(
+  profile: Record<string, unknown> | null | undefined
+): NotificationPreferencesState {
+  const base: NotificationPreferencesState = { ...DEFAULT_NOTIFICATION_PREFERENCES };
+
+  if (profile && typeof profile === 'object') {
+    const raw = (profile as { notificationPreferences?: unknown }).notificationPreferences;
+
+    if (raw && typeof raw === 'object') {
+      (Object.keys(base) as Array<keyof NotificationPreferencesState>).forEach((key) => {
+        const value = (raw as Record<string, unknown>)[key];
+        if (typeof value === 'boolean') {
+          base[key] = value;
+        }
+      });
+    }
+  }
+
+  return base;
+}
+
+function normalizeUser(user: UserDto | AuthUser): AuthUser {
+  if (isAuthUser(user)) {
+    return {
+      ...user,
+      notificationPreferences: {
+        ...DEFAULT_NOTIFICATION_PREFERENCES,
+        ...user.notificationPreferences,
+      },
+    } satisfies AuthUser;
+  }
+
+  const profile = user.profile && typeof user.profile === 'object'
+    ? (user.profile as Record<string, unknown>)
+    : null;
+
+  const notificationPreferences = resolveNotificationPreferences(profile);
+
+  return {
+    id: user.id,
+    email: user.email,
+    role: user.role,
+    emailVerified: Boolean(user.emailVerifiedAt),
+    emailVerifiedAt: user.emailVerifiedAt ?? null,
+    avatarUrl: user.avatarUrl ?? null,
+    displayName: typeof profile?.displayName === 'string' ? (profile.displayName as string) : null,
+    locale: typeof profile?.locale === 'string' ? (profile.locale as string) : null,
+    timezone: typeof profile?.timezone === 'string' ? (profile.timezone as string) : null,
+    profile: profile ?? null,
+    notificationPreferences,
+  } satisfies AuthUser;
+}
+
+function isAuthUser(user: UserDto | AuthUser): user is AuthUser {
+  return Boolean((user as AuthUser).notificationPreferences);
 }
 
 export const useAuth = create<AuthState>()(
@@ -38,10 +122,12 @@ export const useAuth = create<AuthState>()(
           }
 
           const data = await response.json();
-          
+
+          const normalizedUser = normalizeUser(data.user);
+
           set({
             accessToken: data.tokens.accessToken,
-            user: data.user,
+            user: normalizedUser,
             isAuthenticated: true,
           });
         } catch (error) {
@@ -49,7 +135,7 @@ export const useAuth = create<AuthState>()(
           throw error;
         }
       },
-      
+
       logout: () => {
         set({
           accessToken: null,
@@ -57,13 +143,48 @@ export const useAuth = create<AuthState>()(
           isAuthenticated: false,
         });
       },
-      
-      setAuthData: (accessToken: string, user: AuthState['user']) => {
+
+      setAuthData: (accessToken: string, user: UserDto | AuthUser) => {
         set({
           accessToken,
-          user,
+          user: normalizeUser(user),
           isAuthenticated: true,
         });
+      },
+
+      updateUserProfile: (updates: Partial<AuthUser>) => {
+        set((state) => {
+          if (!state.user) {
+            return {};
+          }
+
+          const nextProfile =
+            updates.profile !== undefined ? (updates.profile ?? null) : state.user.profile;
+
+          const nextPreferences = updates.notificationPreferences
+            ? {
+                ...state.user.notificationPreferences,
+                ...updates.notificationPreferences,
+              }
+            : state.user.notificationPreferences;
+
+          return {
+            user: {
+              ...state.user,
+              ...updates,
+              profile: nextProfile,
+              notificationPreferences: nextPreferences,
+            },
+          } satisfies Partial<AuthState>;
+        });
+      },
+
+      setUserFromDto: (userDto: UserDto) => {
+        set((state) => ({
+          accessToken: state.accessToken,
+          isAuthenticated: state.isAuthenticated,
+          user: normalizeUser(userDto),
+        }));
       },
     }),
     {


### PR DESCRIPTION
## Summary
- add profile editing, avatar upload, activity history, notification preferences, and password change experiences to the profile page
- extend the API client with profile update helpers, avatar upload, activity history, notification preferences, and password change endpoints
- expand the auth store to normalize profile details and support syncing notification preferences after updates

## Testing
- pnpm --filter ./app lint
- pnpm --filter ./app type-check

------
https://chatgpt.com/codex/tasks/task_e_68d09f22d76883279fe2cc164df5fe01