### PR TITLE
Fix landing package name

### DIFF
--- a/landing/package-lock.json
+++ b/landing/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "lading",
+  "name": "@supermock/landing",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "lading",
+      "name": "@supermock/landing",
       "version": "0.0.0",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",

--- a/landing/package.json
+++ b/landing/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lading",
+  "name": "@supermock/landing",
   "private": true,
   "version": "0.0.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- rename the landing package to `@supermock/landing`
- align the lockfile metadata with the new scoped package name

## Testing
- pnpm --filter @supermock/landing build *(fails: Next.js build cannot resolve `next/navigation` when invoked via `next-intl`)*

------
https://chatgpt.com/codex/tasks/task_e_68d0c33aa3888327adacdf07a67686d5