### PR TITLE
Install landing dependencies in Docker build

### DIFF
--- a/docker/Dockerfile.landing
+++ b/docker/Dockerfile.landing
@@ -10,6 +10,7 @@ COPY shared/package.json shared/
 RUN corepack enable && pnpm fetch
 
 COPY . .
+RUN pnpm install --offline --frozen-lockfile
 RUN pnpm --filter @supermock/shared build && pnpm --filter @supermock/landing build
 
 FROM node:20-bullseye


### PR DESCRIPTION
## Summary
- install the workspace dependencies during the landing Docker build to materialize node_modules before running package builds

## Testing
- docker build -f docker/Dockerfile.landing -t supermock-landing:test . *(fails: `docker` command unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0c40539e4832787191ae512515c0f