### PR TITLE
Restore translations on landing index page

### DIFF
--- a/landing/src/pages/index.tsx
+++ b/landing/src/pages/index.tsx
@@ -5,21 +5,23 @@ import Footer from "@/components/Footer";
 import Navigation from "@/components/Navigation";
 import ProfessionsSection from "@/components/ProfessionsSection";
 import { handleExternalClick } from "@/lib/utils";
-// Removed Next.js specific imports for Vite compatibility
-import { 
-  Mic, 
-  Code, 
-  MessageCircle, 
-  BarChart3, 
-  FileText, 
+import {
+  Mic,
+  Code,
+  MessageCircle,
+  BarChart3,
+  FileText,
   Gamepad2,
   Lightbulb,
 } from "lucide-react";
-// Hero image will be loaded from public folder
+import type { GetStaticProps } from "next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { useTranslation } from "next-i18next";
+import { nextI18NextConfig } from "@/i18n";
 
 const Index = () => {
-  // Removed translation hooks for Vite compatibility
-  
+  const { t, i18n } = useTranslation();
+
   const languages = [
     { code: "🇺🇸", name: "English" },
     { code: "🇷🇺", name: "Russian" },
@@ -430,5 +432,15 @@ const Index = () => {
     </div>
   );
 };
+
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
+  props: {
+    ...(await serverSideTranslations(
+      locale ?? nextI18NextConfig.i18n?.defaultLocale ?? "en",
+      ["common"],
+      nextI18NextConfig,
+    )),
+  },
+});
 
 export default Index;


### PR DESCRIPTION
## Summary
- reintroduce the next-i18next translation hook on the landing index page to restore access to `t` and `i18n`
- wire up `getStaticProps` with `serverSideTranslations` so SSR receives the required `common` namespace
- clean up temporary Vite compatibility comments left in the page component

## Testing
- `NEXT_DISABLE_ESLINT_PROMPT=1 pnpm --filter ./landing lint` *(fails: command prompts for interactive ESLint setup in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ebce1dac8327822c0c024cff4380