### PR TITLE
Add i18n static props to landing pages

### DIFF
--- a/landing/src/pages/Features.tsx
+++ b/landing/src/pages/Features.tsx
@@ -4,15 +4,18 @@ import FeatureCard from "@/components/FeatureCard";
 import CTASection from "@/components/CTASection";
 import { withBasePath } from "@/lib/routing";
 import { navigateToExternal, handleExternalClick } from "@/lib/utils";
-import { 
-  Mic, 
-  Code, 
-  MessageCircle, 
-  BarChart3, 
-  FileText, 
+import {
+  Mic,
+  Code,
+  MessageCircle,
+  BarChart3,
+  FileText,
   Gamepad2,
   ArrowRight
 } from "lucide-react";
+import type { GetStaticProps } from "next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { nextI18NextConfig } from "@/i18n";
 
 const Features = () => {
   const features = [
@@ -64,5 +67,15 @@ const Features = () => {
     </div>
   );
 };
+
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
+  props: {
+    ...(await serverSideTranslations(
+      locale ?? nextI18NextConfig.i18n?.defaultLocale ?? 'en',
+      ['common'],
+      nextI18NextConfig,
+    )),
+  },
+});
 
 export default Features;

--- a/landing/src/pages/Instructions.tsx
+++ b/landing/src/pages/Instructions.tsx
@@ -2,7 +2,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { withBasePath } from "@/lib/routing";
 import { navigateToExternal, handleExternalClick } from "@/lib/utils";
-import { 
+import {
   Play,
   Users,
   Video,
@@ -17,6 +17,9 @@ import {
 } from "lucide-react";
 import Footer from "@/components/Footer";
 import { useSafeTranslation } from "@/hooks/useSafeTranslation";
+import type { GetStaticProps } from "next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { nextI18NextConfig } from "@/i18n";
 
 const Instructions = () => {
   const { t } = useSafeTranslation();
@@ -233,5 +236,15 @@ const Instructions = () => {
     </div>
   );
 };
+
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
+  props: {
+    ...(await serverSideTranslations(
+      locale ?? nextI18NextConfig.i18n?.defaultLocale ?? 'en',
+      ['common'],
+      nextI18NextConfig,
+    )),
+  },
+});
 
 export default Instructions;

--- a/landing/src/pages/LearningProcess.tsx
+++ b/landing/src/pages/LearningProcess.tsx
@@ -5,10 +5,13 @@ import Footer from "@/components/Footer";
 import { withBasePath } from "@/lib/routing";
 import { navigateToExternal, handleExternalClick } from "@/lib/utils";
 import { useSafeTranslation } from "@/hooks/useSafeTranslation";
+import type { GetStaticProps } from "next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { nextI18NextConfig } from "@/i18n";
 
-import { 
-  Code,  
-  MessageSquare, 
+import {
+  Code,
+  MessageSquare,
   Brain,
   BookOpen,
   RefreshCw,
@@ -398,5 +401,15 @@ const LearningProcess = () => {
     </div>
   );
 };
+
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
+  props: {
+    ...(await serverSideTranslations(
+      locale ?? nextI18NextConfig.i18n?.defaultLocale ?? 'en',
+      ['common'],
+      nextI18NextConfig,
+    )),
+  },
+});
 
 export default LearningProcess;

--- a/landing/src/pages/Pricing.tsx
+++ b/landing/src/pages/Pricing.tsx
@@ -6,6 +6,9 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import Footer from "@/components/Footer";
 import { ArrowRight, Check, X } from "lucide-react";
 import Logo from "@/components/Logo";
+import type { GetStaticProps } from "next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { nextI18NextConfig } from "@/i18n";
 import { useTranslation } from "react-i18next";
 
 const Pricing = () => {
@@ -318,5 +321,15 @@ const Pricing = () => {
     </div>
   );
 };
+
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
+  props: {
+    ...(await serverSideTranslations(
+      locale ?? nextI18NextConfig.i18n?.defaultLocale ?? 'en',
+      ['common'],
+      nextI18NextConfig,
+    )),
+  },
+});
 
 export default Pricing;

--- a/landing/src/pages/PrivacyPolicy.tsx
+++ b/landing/src/pages/PrivacyPolicy.tsx
@@ -6,6 +6,9 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import Footer from "@/components/Footer";
 import { ArrowRight, Shield, Lock, Eye, Users, CreditCard, Mail, MessageCircle } from "lucide-react";
 import Logo from "@/components/Logo";
+import type { GetStaticProps } from "next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { nextI18NextConfig } from "@/i18n";
 
 const PrivacyPolicy = () => {
   const sections = [
@@ -300,5 +303,15 @@ const PrivacyPolicy = () => {
     </div>
   );
 };
+
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
+  props: {
+    ...(await serverSideTranslations(
+      locale ?? nextI18NextConfig.i18n?.defaultLocale ?? 'en',
+      ['common'],
+      nextI18NextConfig,
+    )),
+  },
+});
 
 export default PrivacyPolicy;

--- a/landing/src/pages/Professions.tsx
+++ b/landing/src/pages/Professions.tsx
@@ -4,7 +4,7 @@ import { withBasePath } from "@/lib/routing";
 import { navigateToExternal, handleExternalClick } from "@/lib/utils";
 import Footer from "@/components/Footer";
 import { useSafeTranslation } from "@/hooks/useSafeTranslation";
-import { 
+import {
   Monitor,
   Database,
   Code,
@@ -18,6 +18,9 @@ import {
   ArrowRight
 } from "lucide-react";
 import { professions } from "@/data/professions";
+import type { GetStaticProps } from "next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { nextI18NextConfig } from "@/i18n";
 
 const Professions = () => {
   const { t } = useSafeTranslation();
@@ -121,5 +124,15 @@ const Professions = () => {
     </div>
   );
 };
+
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
+  props: {
+    ...(await serverSideTranslations(
+      locale ?? nextI18NextConfig.i18n?.defaultLocale ?? 'en',
+      ['common'],
+      nextI18NextConfig,
+    )),
+  },
+});
 
 export default Professions;

--- a/landing/src/pages/TermsOfService.tsx
+++ b/landing/src/pages/TermsOfService.tsx
@@ -6,6 +6,9 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import Footer from "@/components/Footer";
 import { ArrowRight, FileText, CheckCircle, AlertTriangle, Clock, Users, Shield, CreditCard } from "lucide-react";
 import Logo from "@/components/Logo";
+import type { GetStaticProps } from "next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { nextI18NextConfig } from "@/i18n";
 
 const TermsOfService = () => {
   const sections = [
@@ -248,5 +251,15 @@ const TermsOfService = () => {
     </div>
   );
 };
+
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
+  props: {
+    ...(await serverSideTranslations(
+      locale ?? nextI18NextConfig.i18n?.defaultLocale ?? 'en',
+      ['common'],
+      nextI18NextConfig,
+    )),
+  },
+});
 
 export default TermsOfService;


### PR DESCRIPTION
## Summary
- add serverSideTranslations-backed getStaticProps to static marketing pages missing i18n hydration
- ensure each page imports the Next.js i18n helpers to support next-i18next when prerendering

## Testing
- pnpm -C landing build

------
https://chatgpt.com/codex/tasks/task_e_68d0fa734a3083278a9c3365491db27c